### PR TITLE
ゴールの優先度表示を明確にするため説明ラベルを追加

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -203,6 +203,13 @@
     "profileAuth": "Profile"
   },
   "scenarios": {
+    "priority": {
+      "highest": "Highest",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "lowest": "Lowest"
+    },
     "title": "Scenario List",
     "subtitle": "Select a scenario to practice. Each scenario has different difficulty levels and NPC characters.",
     "beginner": "Beginner",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -232,6 +232,13 @@
     "profileAuth": "プロフィール"
   },
   "scenarios": {
+    "priority": {
+      "highest": "最高",
+      "high": "高",
+      "medium": "中",
+      "low": "低",
+      "lowest": "最低"
+    },
     "title": "シナリオ一覧",
     "subtitle": "練習したいシナリオを選択してください。各シナリオには異なる難易度とNPCキャラクターが設定されています。",
     "beginner": "初級",

--- a/frontend/src/pages/scenarios/creation/GoalsStep.tsx
+++ b/frontend/src/pages/scenarios/creation/GoalsStep.tsx
@@ -333,7 +333,11 @@ const GoalsStep: React.FC<GoalsStepProps> = ({ formData, updateFormData }) => {
 
               <Box sx={{ mt: 2, mb: 1 }}>
                 <Typography gutterBottom>
-                  {t("scenarios.fields.goalPriority")}: {newGoalPriority}
+                  {t("scenarios.fields.goalPriority")}: {newGoalPriority} {newGoalPriority === 5 ? `(${t("scenarios.priority.highest")})` : 
+                  newGoalPriority === 4 ? `(${t("scenarios.priority.high")})` : 
+                  newGoalPriority === 3 ? `(${t("scenarios.priority.medium")})` : 
+                  newGoalPriority === 2 ? `(${t("scenarios.priority.low")})` : 
+                  `(${t("scenarios.priority.lowest")})`}
                 </Typography>
                 <Slider
                   value={newGoalPriority}
@@ -481,7 +485,11 @@ const GoalsStep: React.FC<GoalsStepProps> = ({ formData, updateFormData }) => {
                     color="text.secondary"
                     sx={{ mt: 1 }}
                   >
-                    {t("scenarios.fields.priority")}: {goal.priority}/5 •
+                    {t("scenarios.fields.priority")}: {goal.priority}/5 {goal.priority === 5 ? `(${t("scenarios.priority.highest")})` : 
+                    goal.priority === 4 ? `(${t("scenarios.priority.high")})` : 
+                    goal.priority === 3 ? `(${t("scenarios.priority.medium")})` : 
+                    goal.priority === 2 ? `(${t("scenarios.priority.low")})` : 
+                    `(${t("scenarios.priority.lowest")})`} •
                     {goal.isRequired
                       ? ` ${t("scenarios.fields.required")}`
                       : ` ${t("scenarios.fields.optional")}`}

--- a/frontend/src/pages/scenarios/creation/PreviewStep.tsx
+++ b/frontend/src/pages/scenarios/creation/PreviewStep.tsx
@@ -361,7 +361,11 @@ const PreviewStep: React.FC<PreviewStepProps> = ({ formData }) => {
                             variant="body2"
                             color="text.primary"
                           >
-                            {t("scenarios.fields.priority")}: {goal.priority}/5
+                            {t("scenarios.fields.priority")}: {goal.priority}/5 {goal.priority === 5 ? `(${t("scenarios.priority.highest")})` : 
+                            goal.priority === 4 ? `(${t("scenarios.priority.high")})` : 
+                            goal.priority === 3 ? `(${t("scenarios.priority.medium")})` : 
+                            goal.priority === 2 ? `(${t("scenarios.priority.low")})` : 
+                            `(${t("scenarios.priority.lowest")})`}
                           </Typography>
                           {" • "}
                           <Typography


### PR DESCRIPTION
## 変更内容
シナリオ作成/更新画面で、ゴールの優先度の数値がわかりにくい問題を改善するため、数値に説明ラベルを追加しました。

### 具体的な変更点
1. 優先度の表示を「{数値}/5」から「{数値}/5 (説明ラベル)」形式に変更
   - 5/5 (最高)
   - 4/5 (高)
   - 3/5 (中)
   - 2/5 (低)
   - 1/5 (最低)

2. 翻訳ファイルに優先度の説明ラベルを追加
   - 日本語: 最高、高、中、低、最低
   - 英語: Highest, High, Medium, Low, Lowest

### 修正ファイル
- `frontend/src/pages/scenarios/creation/GoalsStep.tsx`
- `frontend/src/pages/scenarios/creation/PreviewStep.tsx`
- `frontend/src/i18n/locales/ja.json`
- `frontend/src/i18n/locales/en.json`

### 修正理由
現在の表示では、数値が高いほど優先度が高いことが直感的にわかりにくく、ユーザーによっては1が最優先だと誤解する可能性がありました。説明ラベルを追加することで、数値の意味を明確にし、誤解を防止します。

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1757802750755569 -->

---

**Open in Web UI**: https://d1d37i783mlsjo.cloudfront.net/sessions/1757802750755569