### PR TITLE
AWS CloudShell用のCodeBuildデプロイスクリプトを追加

### DIFF
--- a/bin.sh
+++ b/bin.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+echo ""
+echo "==========================================================================="
+echo "  🚀 AI営業ロールプレイアプリケーション デプロイツール                    "
+echo "---------------------------------------------------------------------------"
+echo "  このスクリプトは、AWS CloudShellからAI営業ロールプレイアプリケーションを"
+echo "  簡単にデプロイするためのものです。                                      "
+echo "                                                                           "
+echo "  作業内容:                                                               "
+echo "  - CloudFormationスタックの作成                                          "
+echo "  - CodeBuildプロジェクトの実行                                           "
+echo "  - アプリケーションのデプロイ（CDK）                                     "
+echo "==========================================================================="
+echo ""
+
+# デフォルトのパラメータ
+ALLOW_SELF_REGISTER="true"
+BEDROCK_REGION="us-east-1"
+CDK_JSON_OVERRIDE="{}"
+REPO_URL="https://github.com/aws-samples/sample-ai-sales-roleplay.git"
+VERSION="main"
+
+# コマンドライン引数の解析
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --disable-self-register) ALLOW_SELF_REGISTER="false" ;;
+        --bedrock-region) BEDROCK_REGION="$2"; shift ;;
+        --cdk-json-override) CDK_JSON_OVERRIDE="$2"; shift ;;
+        --repo-url) REPO_URL="$2"; shift ;;
+        --version) VERSION="$2"; shift ;;
+        *) echo "不明なパラメータ: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+echo "以下の設定でデプロイを開始します:"
+echo "- セルフサインアップ: $ALLOW_SELF_REGISTER"
+echo "- Bedrockリージョン: $BEDROCK_REGION"
+echo "- リポジトリURL: $REPO_URL"
+echo "- バージョン/ブランチ: $VERSION"
+
+if [[ "$CDK_JSON_OVERRIDE" != "{}" ]]; then
+    echo "- CDK設定オーバーライド: $CDK_JSON_OVERRIDE"
+fi
+
+echo ""
+read -p "続行しますか？ (y/N): " answer
+case ${answer:0:1} in
+    y|Y )
+        echo "デプロイを開始します..."
+        ;;
+    * )
+        echo "デプロイをキャンセルしました"
+        exit 1
+        ;;
+esac
+
+# テンプレートの検証
+aws cloudformation validate-template --template-body file://deploy.yml > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "テンプレートの検証に失敗しました"
+    exit 1
+fi
+
+StackName="AIRoleplayDeployStack"
+
+# CloudFormationスタックのデプロイ
+echo "CloudFormationスタックのデプロイを開始します..."
+aws cloudformation deploy \
+  --stack-name $StackName \
+  --template-file deploy.yml \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    AllowSelfRegister=$ALLOW_SELF_REGISTER \
+    BedrockRegion="$BEDROCK_REGION" \
+    CdkJsonOverride="$CDK_JSON_OVERRIDE" \
+    RepoUrl="$REPO_URL" \
+    Version="$VERSION"
+
+echo "スタック作成の完了を待機しています..."
+echo "注: このスタックはCDKデプロイ用のCodeBuildプロジェクトを含みます。"
+spin='-\|/'
+i=0
+while true; do
+    status=$(aws cloudformation describe-stacks --stack-name $StackName --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
+    if [[ "$status" == "CREATE_COMPLETE" || "$status" == "UPDATE_COMPLETE" ]]; then
+        break
+    elif [[ "$status" == "ROLLBACK_COMPLETE" || "$status" == "DELETE_FAILED" || "$status" == "CREATE_FAILED" ]]; then
+        echo "スタック作成に失敗しました: $status"
+        exit 1
+    fi
+    printf "\r${spin:i++%${#spin}:1}"
+    sleep 1
+done
+echo -e "\n完了しました。\n"
+
+# スタックの出力情報を取得
+outputs=$(aws cloudformation describe-stacks --stack-name $StackName --query 'Stacks[0].Outputs')
+projectName=$(echo $outputs | jq -r '.[] | select(.OutputKey=="ProjectName").OutputValue')
+
+if [[ -z "$projectName" ]]; then
+    echo "CodeBuildプロジェクト名の取得に失敗しました"
+    exit 1
+fi
+
+echo "CodeBuildプロジェクト $projectName を開始します..."
+buildId=$(aws codebuild start-build --project-name $projectName --query 'build.id' --output text)
+
+if [[ -z "$buildId" ]]; then
+    echo "CodeBuildプロジェクトの開始に失敗しました"
+    exit 1
+fi
+
+echo "CodeBuildプロジェクトの完了を待機しています..."
+echo "ビルドID: $buildId"
+while true; do
+    buildStatus=$(aws codebuild batch-get-builds --ids $buildId --query 'builds[0].buildStatus' --output text)
+    if [[ "$buildStatus" == "SUCCEEDED" || "$buildStatus" == "FAILED" || "$buildStatus" == "STOPPED" ]]; then
+        break
+    fi
+    printf "."
+    sleep 10
+done
+echo -e "\nCodeBuildプロジェクトのステータス: $buildStatus"
+
+if [[ "$buildStatus" == "SUCCEEDED" ]]; then
+    echo "デプロイが正常に完了しました！"
+    
+    # ビルドログの取得
+    buildDetail=$(aws codebuild batch-get-builds --ids $buildId --query 'builds[0].logs.{groupName: groupName, streamName: streamName}' --output json)
+    logGroupName=$(echo $buildDetail | jq -r '.groupName')
+    logStreamName=$(echo $buildDetail | jq -r '.streamName')
+    
+    echo "ログ情報:"
+    echo "- グループ名: $logGroupName"
+    echo "- ストリーム名: $logStreamName"
+    
+    # CDKアプリケーションのURLを抽出
+    logs=$(aws logs get-log-events --log-group-name $logGroupName --log-stream-name $logStreamName)
+    frontendUrl=$(echo "$logs" | grep -o 'FrontendURL = [^ ]*' | cut -d' ' -f3 | tr -d '\n,')
+    
+    if [[ -n "$frontendUrl" ]]; then
+        echo -e "\n🌐 アプリケーションURL: $frontendUrl"
+    else
+        echo -e "\nアプリケーションURLが見つかりませんでした。ログを確認してください。"
+    fi
+else
+    echo "デプロイに失敗しました。CodeBuildログを確認してください。"
+fi

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,0 +1,167 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Template to deploy the AI Sales Roleplay application using CodeBuild
+
+Parameters:
+  AllowSelfRegister:
+    Type: String
+    Default: "true"
+  BedrockRegion:
+    Type: String
+    Default: "us-east-1"
+    Description: "The AWS region where Amazon Bedrock services are available"
+  CdkJsonOverride:
+    Type: String
+    Default: "{}"
+    Description: "JSON object to override CDK configuration"
+  RepoUrl:
+    Type: String
+    Default: "https://github.com/aws-samples/sample-ai-sales-roleplay.git"
+    Description: "GitHub repository URL"
+  Version:
+    Type: String
+    Default: "main"
+    Description: "Branch or tag to deploy"
+
+Resources:
+  ProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/AdministratorAccess
+
+  ProjectRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: Project
+                    - :*
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":logs:"
+                    - Ref: AWS::Region
+                    - ":"
+                    - Ref: AWS::AccountId
+                    - :log-group:/aws/codebuild/
+                    - Ref: Project
+          - Action:
+              - codebuild:BatchPutCodeCoverages
+              - codebuild:BatchPutTestCases
+              - codebuild:CreateReport
+              - codebuild:CreateReportGroup
+              - codebuild:UpdateReport
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":codebuild:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :report-group/
+                  - Ref: Project
+                  - -*
+        Version: "2012-10-17"
+      PolicyName: ProjectRoleDefaultPolicy
+      Roles:
+        - Ref: ProjectRole
+
+  Project:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Cache:
+        Type: NO_CACHE
+      EncryptionKey: alias/aws/s3
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: ALLOW_SELF_REGISTER
+            Value: !Ref AllowSelfRegister
+          - Name: BEDROCK_REGION
+            Value: !Ref BedrockRegion
+          - Name: CDK_JSON_OVERRIDE
+            Value: !Ref CdkJsonOverride
+          - Name: REPO_URL
+            Value: !Ref RepoUrl
+          - Name: VERSION
+            Value: !Ref Version
+      ServiceRole:
+        Fn::GetAtt:
+          - ProjectRole
+          - Arn
+      Source:
+        BuildSpec: |-
+          {
+            "version": 0.2,
+            "phases": {
+              "install": {
+                "runtime-versions": {
+                  "nodejs": "18"
+                },
+                "on-failure": "ABORT",
+                "commands": [
+                  "echo 'Installing dependencies...'"
+                ]
+              },
+              "build": {
+                "commands": [
+                  "echo 'Build phase started...'",
+                  "git clone --branch $VERSION $REPO_URL ai-sales-roleplay",
+                  "cd ai-sales-roleplay",
+                  "if [ \"$ALLOW_SELF_REGISTER\" = \"false\" ]; then sed -i 's/\"selfSignUpEnabled\": true/\"selfSignUpEnabled\": false/' cdk/cdk.json; fi",
+                  "sed -i \"s/\\\"bedrockRegion\\\": \\\"[^\\\"]*\\\"/\\\"bedrockRegion\\\": \\\"${BEDROCK_REGION}\\\"/\" cdk/cdk.json",
+                  "echo \"$CDK_JSON_OVERRIDE\" | jq '.' && jq --argjson override \"$CDK_JSON_OVERRIDE\" '. * $override' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json",
+                  "cd frontend",
+                  "npm ci",
+                  "npm run build",
+                  "cd ../cdk",
+                  "npm ci",
+                  "npx cdk bootstrap",
+                  "npx cdk deploy --require-approval never --all"
+                ]
+              }
+            }
+          }
+        Type: NO_SOURCE
+
+Outputs:
+  ProjectName:
+    Value:
+      Ref: Project
+    Description: "CodeBuild project name"


### PR DESCRIPTION
## 概要
AWSのCloudShellから簡単にデプロイできるように、CodeBuildを使用したデプロイ手段を提供しました。

## 追加した機能
- `bin.sh`: デプロイを実行するメインスクリプト
- `deploy.yml`: CloudFormationテンプレート（CodeBuildプロジェクト用）

## 使い方
CloudShellで以下のコマンドを実行するだけでデプロイが可能です：
```bash
chmod +x bin.sh
./bin.sh
```

## オプション機能
以下のオプションパラメータをサポートしています：
- `--disable-self-register`: セルフ登録を無効にする
- `--bedrock-region`: Amazon Bedrockが利用可能なリージョンを指定（デフォルト: us-east-1）
- `--cdk-json-override`: CDK設定のオーバーライドを指定
- `--repo-url`: 別のリポジトリURLを指定
- `--version`: 別のブランチまたはタグを指定

## 重要な点
デフォルトのリポジトリURLは `https://github.com/aws-samples/sample-ai-sales-roleplay.git` を使用しています。

## 参考情報
aws-samples/bedrock-chatリポジトリのデプロイスクリプトを参考に、AI営業ロールプレイアプリケーション向けにカスタマイズしました。

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1757294004114619 -->

---

**Open in Web UI**: https://d1d37i783mlsjo.cloudfront.net/sessions/1757294004114619