### PR TITLE
READMEにCloudShellを使った簡単デプロイ方法を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,40 @@
 - AWS CLI最新版
 - AWS CDK最新版
 
-### インストール
+### デプロイ方法
+
+#### AWS CloudShellを使った簡単デプロイ
+
+事前準備不要で、AWS CloudShellを使って簡単にデプロイできます：
+
+1. **AWS コンソールにログイン**して、画面上部のCloudShellアイコン（ターミナルマーク）をクリックします
+
+2. **以下のコマンドを実行**
+```bash
+# リポジトリをクローン
+git clone https://github.com/aws-samples/sample-ai-sales-roleplay.git
+cd sample-ai-sales-roleplay
+
+# デプロイスクリプトを実行
+chmod +x bin.sh
+./bin.sh
+```
+
+3. **デプロイオプション**（任意）
+```bash
+# セルフサインアップ機能を無効化
+./bin.sh --disable-self-register
+
+# 別のBedrockリージョンを使用
+./bin.sh --bedrock-region us-west-2
+
+# 詳細なカスタマイズ
+./bin.sh --cdk-json-override '{"context":{"allowedSignUpEmailDomains":["example.com"]}}'
+```
+
+4. **デプロイ完了後、表示されるURLからアプリケーションにアクセスできます**
+
+#### 手動インストール
 
 1. **リポジトリのクローン**
 ```bash
@@ -63,7 +96,6 @@ cd sample-ai-sales-roleplay
 
 2. **依存関係のインストール**
 ```bash
-
 # フロントエンド
 cd frontend
 npm install


### PR DESCRIPTION
## 概要
READMEに AWS CloudShellを使って簡単にデプロイできる手順を追加しました。

## 変更内容
- READMEの「デプロイ方法」セクションを追加
- CloudShellを使った簡単デプロイ手順を詳細に記載
- 既存の手動インストール方法も「手動インストール」として整理

## 追加したCloudShellデプロイ手順
1. AWSコンソールからCloudShellを起動
2. リポジトリをクローン
3. `bin.sh`スクリプトを実行するだけでデプロイが完了

## オプション機能の説明
- セルフサインアップ無効化オプション
- Bedrockリージョン指定オプション
- JSON設定オーバーライドオプション

この変更により、事前準備なしで簡単にデプロイできるようになります。

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1757294004114619 -->

---

**Open in Web UI**: https://d1d37i783mlsjo.cloudfront.net/sessions/1757294004114619