### PR TITLE
ゴール達成時の自動会話終了を無効化

### DIFF
--- a/frontend/src/pages/ConversationPage.tsx
+++ b/frontend/src/pages/ConversationPage.tsx
@@ -861,13 +861,12 @@ const ConversationPage: React.FC = () => {
         // 例: トースト通知やアラートなど
         console.log(`ゴール達成: ${goal.description}`);
 
-        // 必須ゴールがすべて達成された場合、セッションを終了
+        // 必須ゴールがすべて達成された場合の処理
+        // ゴール達成のみでは自動終了しないように修正
+        // (ユーザーが自分でクロージングを進められるようにするため)
         if (areAllRequiredGoalsAchieved(goalStatuses, goals)) {
-          setTimeout(async () => {
-            if (!sessionEnded && messages.length > 0) {
-              await endSession(messages, currentMetrics);
-            }
-          }, 2000);
+          console.log("すべての必須ゴールが達成されました。会話を継続します。");
+          // 自動終了処理を削除し、ユーザーが会話を続けられるようにする
         }
       }
     }


### PR DESCRIPTION
## 変更内容
- ゴールをすべて達成した際に自動的に会話が終了する機能を無効化しました
- ユーザーが自分でNext Stepの提案などクロージングに向けた会話を続けられるようになります

## 対象コード
`frontend/src/pages/ConversationPage.tsx`の自動終了処理を削除し、ゴール達成時にはログメッセージを出力するのみにしました。

## テスト方法
1. 会話を開始し、すべてのゴールを達成する
2. 従来であれば自動的に結果画面に遷移していたが、修正後は会話が継続することを確認
3. ユーザーが自分のタイミングで「終了」ボタンを押すことで会話を終えられることを確認

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1758328447548749 -->

---

**Open in Web UI**: https://d1d37i783mlsjo.cloudfront.net/sessions/1758328447548749