### PR TITLE
feat: Claude Sonnet 4および4.5モデルへの対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 **バックエンド**
 - AWS CDK（インフラストラクチャ）
 - AWS Lambda (Python 3.13) + API Gateway
-- Amazon Bedrock (Claude 3.5 Haiku)
+- Amazon Bedrock (Claude 3.5 Haiku, Claude Sonnet 4.5)
 - Amazon Polly（音声合成）
 - Amazon Bedrock Guardrails（コンプライアンスチェック）
 - DynamoDB + RDS PostgreSQL

--- a/bin.sh
+++ b/bin.sh
@@ -70,6 +70,10 @@ while [[ "$#" -gt 0 ]]; do
             echo "  us.anthropic.claude-3-5-haiku-20241022-v1:0"
             echo "  us.anthropic.claude-3-5-sonnet-20241022-v2:0"
             echo "  us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+            echo "  us.anthropic.claude-sonnet-4-20250514-v1:0"
+            echo "  us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            echo "  global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            echo "  jp.anthropic.claude-sonnet-4-5-20250929-v1:0"
             echo "  us.amazon.nova-lite-v1:0"
             echo "  us.amazon.nova-pro-v1:0"
             exit 0

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -24,26 +24,26 @@
         "us-regions": {
           "conversation": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "scoring": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-          "feedback": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "us.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "video": "us.amazon.nova-lite-v1:0",
-          "referenceCheck": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-regions": {
           "conversation": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "apac.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "apac.amazon.nova-lite-v1:0",
-          "referenceCheck": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-regions": {
           "conversation": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "eu.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "eu.amazon.nova-lite-v1:0",
-          "referenceCheck": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         }
       },
       "allowedIpV4AddressRanges": null,
@@ -57,26 +57,26 @@
         "us-regions": {
           "conversation": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "scoring": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-          "feedback": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "us.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "video": "us.amazon.nova-lite-v1:0",
-          "referenceCheck": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-regions": {
           "conversation": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "apac.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "apac.amazon.nova-lite-v1:0",
-          "referenceCheck": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-regions": {
           "conversation": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "eu.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "eu.amazon.nova-lite-v1:0",
-          "referenceCheck": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         }
       },
       "allowedIpV4AddressRanges": null,
@@ -90,26 +90,26 @@
         "us-regions": {
           "conversation": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "scoring": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-          "feedback": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "us.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "video": "us.amazon.nova-lite-v1:0",
-          "referenceCheck": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-regions": {
           "conversation": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "apac.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "apac.amazon.nova-lite-v1:0",
-          "referenceCheck": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-regions": {
           "conversation": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "eu.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "eu.amazon.nova-lite-v1:0",
-          "referenceCheck": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         }
       },
       "allowedIpV4AddressRanges": null,
@@ -123,26 +123,26 @@
         "us-regions": {
           "conversation": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "scoring": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-          "feedback": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "us.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
           "video": "us.amazon.nova-lite-v1:0",
-          "referenceCheck": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-regions": {
           "conversation": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "apac.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "apac.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "apac.amazon.nova-lite-v1:0",
-          "referenceCheck": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-regions": {
           "conversation": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "scoring": "eu.anthropic.claude-3-haiku-20240307-v1:0",
-          "feedback": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "feedback": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
           "guardrail": "eu.anthropic.claude-3-haiku-20240307-v1:0",
           "video": "eu.amazon.nova-lite-v1:0",
-          "referenceCheck": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "referenceCheck": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         }
       },
       "allowedIpV4AddressRanges": null,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -3112,46 +3112,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa": {
-      "name": "safe-execa",
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.2.tgz",
-      "integrity": "sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zkochan/which": "^2.0.3",
-        "execa": "^5.1.1",
-        "path-name": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file": {
       "version": "8.1.8",
       "inBundle": true,
@@ -3183,20 +3143,6 @@
       },
       "peerDependencies": {
         "@pnpm/logger": "^5.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file/node_modules/js-yaml": {
-      "name": "@zkochan/js-yaml",
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-types": {
@@ -3485,6 +3431,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws/pdk/node_modules/arg": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws/pdk/node_modules/argparse": {
       "version": "2.0.1",
       "inBundle": true,
@@ -3551,6 +3502,14 @@
       "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/@aws/pdk/node_modules/builtins": {
       "version": "5.1.0",
@@ -3830,13 +3789,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4168,6 +4120,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@aws/pdk/node_modules/glob": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/globalthis": {
       "version": "1.0.4",
       "inBundle": true,
@@ -4356,6 +4326,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/@aws/pdk/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/is-async-function": {
       "version": "2.1.1",
@@ -4688,9 +4663,7 @@
       }
     },
     "node_modules/@aws/pdk/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -4742,6 +4715,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aws/pdk/node_modules/lines-and-columns": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/load-json-file": {
       "version": "6.2.0",
       "inBundle": true,
@@ -4752,16 +4733,6 @@
         "strip-bom": "^4.0.0",
         "type-fest": "^0.6.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -4892,16 +4863,6 @@
         "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
-    "node_modules/@aws/pdk/node_modules/mem/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/merge-stream": {
       "version": "2.0.0",
       "inBundle": true,
@@ -4913,6 +4874,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/minimatch": {
+      "version": "10.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@aws/pdk/node_modules/ms": {
@@ -4940,29 +4915,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/hosted-git-info": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
-      "integrity": "sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^7.5.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@aws/pdk/node_modules/normalize-path": {
@@ -5078,6 +5030,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws/pdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/p-locate": {
       "version": "4.1.0",
       "inBundle": true,
@@ -5087,22 +5053,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aws/pdk/node_modules/parse-json": {
@@ -5121,13 +5071,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/parse-json/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/parse-unit": {
       "version": "1.0.1",
@@ -5201,46 +5144,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@aws/pdk/node_modules/read-yaml-file": {
@@ -5338,52 +5241,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@aws/pdk/node_modules/safe-array-concat": {
@@ -5653,41 +5510,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "inBundle": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "inBundle": true,
@@ -5854,13 +5676,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@aws/pdk/node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/type-fest": {
       "version": "0.8.1",
@@ -6131,19 +5946,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/write-yaml-file": {
       "version": "5.0.0",
       "inBundle": true,
@@ -6184,6 +5986,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -10187,15 +10000,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gauge": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
@@ -10372,18 +10176,6 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "license": "ISC"
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10510,21 +10302,6 @@
       },
       "bin": {
         "is-ci": "bin.js"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -12180,12 +11957,6 @@
       "integrity": "sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==",
       "license": "MIT"
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
     "node_modules/path-scurry": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
@@ -13155,26 +12926,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -13590,18 +13341,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {

--- a/docs/deployment/bin-sh-reference.md
+++ b/docs/deployment/bin-sh-reference.md
@@ -148,7 +148,13 @@ export AWS_DEFAULT_REGION=ap-northeast-1
 | `us.anthropic.claude-3-5-haiku-20241022-v1:0` | 高速・低コスト | 対話、スコアリング、ガードレール | US |
 | `us.anthropic.claude-3-5-sonnet-20241022-v2:0` | バランス型・高品質 | 対話（高品質が必要な場合） | US |
 | `us.anthropic.claude-3-7-sonnet-20250219-v1:0` | 最高品質・高コスト | フィードバック、リファレンスチェック | US, AP, EU |
+| `us.anthropic.claude-sonnet-4-20250514-v1:0` | 次世代高性能 | フィードバック、リファレンスチェック | US |
+| `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | 最新最高性能 | フィードバック、リファレンスチェック | US |
+| `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | 最新最高性能 | フィードバック、リファレンスチェック | Global |
+| `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` | 最新最高性能 | フィードバック、リファレンスチェック | Japan |
+| `apac.anthropic.claude-sonnet-4-20250514-v1:0` | 次世代高性能 | フィードバック、リファレンスチェック | AP |
 | `apac.anthropic.claude-3-haiku-20240307-v1:0` | 高速・低コスト | 対話、スコアリング、ガードレール | AP |
+| `eu.anthropic.claude-sonnet-4-20250514-v1:0` | 次世代高性能 | フィードバック、リファレンスチェック | EU |
 | `eu.anthropic.claude-3-haiku-20240307-v1:0` | 高速・低コスト | 対話、スコアリング、ガードレール | EU |
 
 ### Amazon Nova モデル
@@ -181,5 +187,3 @@ IP アドレス制限や地理的制限を設定する場合は、`--cdk-json-ov
   }
 }'
 ```
-
-


### PR DESCRIPTION
## 概要
Claude Sonnet 4および4.5モデルへの対応を実装しました。

## 変更内容
- cdk.json: 全環境でClaude 3.7 SonnetをClaude Sonnet 4に更新
- feedback/referenceCheck機能でClaude Sonnet 4を使用
- リージョン固有エンドポイントを優先使用（us, apac, eu）
- bin.sh: 新しいモデルIDの例をヘルプに追加
- README.md: 技術スタック情報を更新
- docs: モデル一覧表にSonnet 4/4.5を追加

## リージョン別対応
- USリージョン: us.anthropic.claude-sonnet-4-20250514-v1:0
- APリージョン: apac.anthropic.claude-sonnet-4-20250514-v1:0
- EUリージョン: eu.anthropic.claude-sonnet-4-20250514-v1:0

## テスト
- [ ] 各リージョンでのデプロイテスト
- [ ] feedback機能の動作確認
- [ ] referenceCheck機能の動作確認