### PR TITLE
Add English README and fix dependency/language handling issues

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,180 @@
+# AI Sales Roleplay
+
+## Overview
+A roleplay system for improving sales skills using generative AI. Users can develop practical sales skills through voice-based conversations with emotionally expressive AI.
+This system is designed for junior sales representatives, helping them improve their sales skills through interactive simulations with AI.
+
+### Key Features
+
+- **Voice Conversation with AI**: Natural conversations powered by Amazon Bedrock
+- **Real-time Emotional Feedback**: Visualization of anger meter, trust level, and progress
+- **Diverse Scenarios**: Customizable sales scenes
+- **Detailed Analysis Reports**: Improvement suggestions and feedback after each session
+- **Video Analysis During Conversation**: Analyzes video during sessions to verify effective eye contact and gestures
+- **Compliance Violation Check**: Identifies statements that violate compliance rules
+- **Reference Check**: Verifies whether user statements are based on reference materials
+
+### Screenshots
+
+![](./docs/image/demo_image_1.png)
+
+![](./docs/image/demo_image_2.png)
+
+![](./docs/image/demo_image_3.png)
+
+![](./docs/image/demo_image_4.png)
+
+### Technology Stack
+
+**Frontend**
+- React 19 + TypeScript
+- Material UI 7
+- Vite 6 (Build tool)
+- AWS Amplify v6 (Authentication)
+- React Context API (State management)
+
+**Backend**
+- AWS CDK (Infrastructure as Code)
+- AWS Lambda (Python 3.13) + API Gateway
+- Amazon Bedrock (Claude 3.5 Haiku, Claude Sonnet 4.5)
+- Amazon Polly (Text-to-speech)
+- Amazon Bedrock Guardrails (Compliance check)
+- DynamoDB + RDS PostgreSQL
+- Amazon S3 (PDF materials, audio files)
+- Amazon Cognito (Authentication)
+
+### Architecture
+![](./docs/image/Architecture.png)
+
+## Setup
+
+### Prerequisites
+
+- Docker
+- Node.js 22.x or higher
+- Python 3.12 or higher
+- Latest AWS CLI
+- Latest AWS CDK
+
+### Deployment
+
+#### Quick Deployment with AWS CloudShell
+
+You can easily deploy without any prerequisites using AWS CloudShell:
+
+1. **Log in to AWS Console** and click the CloudShell icon (terminal mark) at the top of the screen
+
+2. **Run the following commands**
+```bash
+# Clone the repository
+git clone https://github.com/aws-samples/sample-ai-sales-roleplay.git
+cd sample-ai-sales-roleplay
+
+# Run deployment script
+chmod +x bin.sh
+./bin.sh
+```
+
+3. **Deployment Options** (optional)
+```bash
+# Disable self-registration feature
+./bin.sh --disable-self-register
+
+# Use a different region
+export AWS_DEFAULT_REGION=ap-northeast-1
+./bin.sh
+
+# Specify individual models
+./bin.sh --conversation-model "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+# Detailed customization
+./bin.sh --cdk-json-override '{"context":{"default":{"allowedSignUpEmailDomains":["example.com"]}}}'
+```
+
+4. **After deployment completes, you can access the application from the displayed URL**
+
+#### Manual Installation
+
+1. **Clone the repository**
+```bash
+git clone https://github.com/aws-samples/sample-ai-sales-roleplay.git
+cd sample-ai-sales-roleplay
+```
+
+2. **Install dependencies**
+```bash
+# Frontend
+cd frontend
+npm install
+
+# Backend
+cd ../cdk
+npm install
+```
+
+3. **Environment Setup**
+Refer to [AI Sales Roleplay Environment Setup](./cdk/README.md) (Japanese)
+
+## Documentation
+
+### Deployment & Configuration
+- [bin.sh Deployment Script Reference](docs/deployment/bin-sh-reference.md) (Japanese)
+
+### Feature Specifications
+- [Scenario Creation Guide](docs/scenario-creation.md) (Japanese)
+- [Video Analysis Feature](docs/video-analysis.md) (Japanese)
+
+### API & Technical Specifications
+- [Polly Lexicon Guide](docs/custom-resources/polly-lexicon-guide.md) (Japanese)
+
+### Operations & Cost
+- [Cost Estimation](docs/cost/コスト試算.md) (Japanese)
+
+*Note: Most documentation is currently in Japanese. English translations are planned for future updates.*
+
+## Project Structure
+
+```
+├── frontend/                    # React application
+│   ├── src/
+│   │   ├── components/         # UI components
+│   │   ├── pages/              # Application pages
+│   │   ├── services/           # API services, authentication, etc.
+│   │   ├── hooks/              # Custom React hooks
+│   │   ├── types/              # TypeScript type definitions
+│   │   ├── utils/              # Utility functions
+│   │   ├── i18n/               # Internationalization settings
+│   │   └── config/             # Configuration files
+│   └── docs/                   # Frontend-specific documentation
+├── cdk/                        # AWS CDK infrastructure code
+│   ├── lib/
+│   │   ├── constructs/         # Reusable CDK constructs
+│   │   │   ├── api/            # API Gateway related
+│   │   │   ├── storage/        # S3, DynamoDB related
+│   │   │   └── compute/        # Lambda related
+│   │   └── stacks/             # Deployable stacks
+│   ├── lambda/                 # Lambda function implementations
+│   │   ├── bedrock/            # Amazon Bedrock integration
+│   │   ├── scoring/            # Scoring engine
+│   │   ├── textToSpeech/       # Text-to-speech synthesis
+│   │   ├── scenarios/          # Scenario management
+│   │   ├── sessions/           # Session management
+│   │   ├── guardrails/         # Guardrails management
+│   │   ├── rankings/           # Ranking features
+│   │   └── videos/             # Video processing
+│   └── data/                   # Initial data (scenarios, Guardrails config)
+├── docs/                       # Project documentation
+│   ├── api/                    # API specifications
+│   ├── cost/                   # Cost estimation
+│   ├── custom-resources/       # Custom resource guides
+│   └── features/               # Feature specifications
+└── .kiro/                      # Kiro AI configuration files
+```
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License. See the LICENSE file.

--- a/cdk/lambda/audioAnalysis/requirements.txt
+++ b/cdk/lambda/audioAnalysis/requirements.txt
@@ -1,4 +1,4 @@
-strands-agents
-strands-agents-tools
+strands-agents==1.11.0
+strands-agents-tools==0.2.12
 boto3==1.40.24
 aws-lambda-powertools==3.19.0

--- a/cdk/lambda/referenceCheck/agent/agent.py
+++ b/cdk/lambda/referenceCheck/agent/agent.py
@@ -19,13 +19,6 @@ boto_config = BotocoreConfig(
     read_timeout=300,
 )
 
-# システムプロンプトは言語に応じて動的に設定するため、ここでは基本設定のみ
-bedrock_model_base = BedrockModel(
-    model_id=BEDROCK_MODEL_REFERENCE_CHECK,
-    region_name=REGION,
-    boto_client_config=boto_config,
-)
-
 
 def call_agent(
     user_message: str, context: str, scenario_id: str, language: str = "ja"
@@ -158,12 +151,13 @@ check_single_message_reference: Knowledge Baseのクエリが可能。ユーザ�
 - related: ユーザーの発言に問題があるかどうか。ドキュメントとの矛盾、または一般的な営業ベストプラクティスに反する場合はfalse、それ以外はtrue（true/false）
 """
         
+        logger.debug(f"BEDROCK_MODEL_REFERENCE_CHECK: {BEDROCK_MODEL_REFERENCE_CHECK}")
         # 言語に応じたBedrockModelを作成
         bedrock_model = BedrockModel(
-            model_id=bedrock_model_base.model_id,
-            region_name=bedrock_model_base.region_name,
+            model_id=BEDROCK_MODEL_REFERENCE_CHECK,
+            region_name=REGION,
             system_prompt=system_prompt,
-            boto_client_config=bedrock_model_base.boto_client_config,
+            boto_client_config=boto_config
         )
 
         logger.debug(f"prompt: {prompt}")

--- a/cdk/lambda/referenceCheck/requirements.txt
+++ b/cdk/lambda/referenceCheck/requirements.txt
@@ -1,4 +1,4 @@
-strands-agents
-strands-agents-tools
+strands-agents==1.11.0
+strands-agents-tools==0.2.12
 boto3==1.40.24
 aws-lambda-powertools==3.19.0

--- a/cdk/lambda/sessions/analysis_results_handlers.py
+++ b/cdk/lambda/sessions/analysis_results_handlers.py
@@ -572,7 +572,7 @@ def register_analysis_results_routes(app: APIGatewayRestResolver):
                             messages=messages,
                             goal_statuses=current_goal_statuses,
                             scenario_goals=scenario_goals,
-                            language=session_info.get('language', 'ja')
+                            language=scenario_info.get('language', 'ja') if scenario_info else 'ja'
                         )
                         
                         logger.info("通常セッションフィードバック生成完了", extra={


### PR DESCRIPTION
## 変更内容

### ドキュメント
- 英語版READMEの追加（README_en.md）
  - プロジェクト概要、主要機能、技術スタック
  - セットアップ手順とデプロイメント方法
  - スクリーンショットとアーキテクチャ図

### 依存関係の改善
- strands-agentsとstrands-agents-toolsのバージョンを明示的に固定
  - strands-agents==1.11.0
  - strands-agents-tools==0.2.12
  - 再現性の向上とバージョン競合の防止

### バグ修正
- referenceCheck AgentのBedrockModel初期化ロジック改善
  - 言語ごとに異なるsystem_promptを設定可能に
- 分析結果ハンドラーの言語パラメータ取得ロジック修正
  - scenario_infoから正しくlanguageを取得

## テスト

- [ ] ローカルでの動作確認
- [ ] 英語版READMEのレビュー
- [ ] referenceCheck機能の動作確認（日本語・英語）