### PR TITLE
AgentCore RuntimeのBedrock Cross-Region Inference Profile対応

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -163,6 +163,20 @@ Amazon Bedrock AgentCore Runtimeを使用したエージェント実行基盤を
 | **realtime-scoring** | リアルタイムスコアリング | AgentCore Identity (JWT) |
 | **feedback-analysis** | フィードバック分析 | IAMロール |
 
+### ⚠️ サードパーティモデル利用時の注意（Cross-Region Inference Profile）
+
+AgentCore Runtimeから `global.anthropic.claude-*` 等のcross-region inference profileモデルを利用する場合、以下の前提条件を満たす必要があります。不足している場合、初回呼び出しは成功しても2回目以降で `AccessDeniedException` が発生します。
+
+1. **AWS Marketplace権限**: AgentCore Runtime実行ロールに `aws-marketplace:Subscribe`、`aws-marketplace:Unsubscribe`、`aws-marketplace:ViewSubscriptions` 権限が必要です。Bedrockがサードパーティモデル（Anthropic等）の自動サブスクリプションを行う際に使用されます。
+
+2. **Inference Profile ARN**: IAMポリシーのリソースに `arn:aws:bedrock:*:<account>:inference-profile/*` を含める必要があります。`foundation-model/*` だけでは不十分です。
+
+3. **Anthropic FTUフォーム**: Anthropicモデルを初めて利用する場合、Bedrock コンソールでFirst Time Use（FTU）フォームの完了が必要です。
+
+4. **有効な支払い方法**: AWSアカウントにAWS Marketplace購入用の有効な支払い方法が設定されている必要があります。
+
+詳細: [Understanding automatic model access - Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
+
 ### AgentCore Memory
 
 AgentCore Memoryを使用して会話履歴とメトリクスを管理します：

--- a/cdk/lib/constructs/agentcore/agentcore-runtime.ts
+++ b/cdk/lib/constructs/agentcore/agentcore-runtime.ts
@@ -67,12 +67,28 @@ export class AgentCoreRuntime extends Construct {
     // Runtime Endpointを追加
     runtime.addEndpoint('DefaultEndpoint', {});
 
-    // Bedrock InvokeModel権限を付与
+    // Bedrock InvokeModel権限を付与（Cross-region inference profile対応）
     runtime.addToRolePolicy(new iam.PolicyStatement({
       sid: 'BedrockModelInvocation',
       effect: iam.Effect.ALLOW,
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
-      resources: ['arn:aws:bedrock:*::foundation-model/*', `arn:aws:bedrock:${region}:${account}:*`],
+      resources: [
+        'arn:aws:bedrock:*::foundation-model/*',
+        `arn:aws:bedrock:*:${account}:inference-profile/*`,
+        `arn:aws:bedrock:${region}:${account}:*`,
+      ],
+    }));
+
+    // AWS Marketplace権限（サードパーティモデルの自動サブスクリプションに必要）
+    runtime.addToRolePolicy(new iam.PolicyStatement({
+      sid: 'MarketplaceModelAccess',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'aws-marketplace:Subscribe',
+        'aws-marketplace:Unsubscribe',
+        'aws-marketplace:ViewSubscriptions',
+      ],
+      resources: ['*'],
     }));
 
     // AgentCore Memory権限を付与（Memory IDが指定されている場合）

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1227,6 +1227,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.948.0.tgz",
       "integrity": "sha512-DIUH70KaFjOPezX2oHAC1Ky8hlUBnf0C7lB+1SBdLcjS1b/rbBTlWHmCOc0wC8cOG507gbxhwqmOX9RU/GX3+w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -5284,6 +5285,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
       "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -5780,46 +5782,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa": {
-      "name": "safe-execa",
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.2.tgz",
-      "integrity": "sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zkochan/which": "^2.0.3",
-        "execa": "^5.1.1",
-        "path-name": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file": {
       "version": "8.1.8",
       "inBundle": true,
@@ -5851,20 +5813,6 @@
       },
       "peerDependencies": {
         "@pnpm/logger": "^5.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file/node_modules/js-yaml": {
-      "name": "@zkochan/js-yaml",
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-types": {
@@ -6153,6 +6101,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws/pdk/node_modules/arg": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws/pdk/node_modules/argparse": {
       "version": "2.0.1",
       "inBundle": true,
@@ -6219,6 +6172,14 @@
       "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/@aws/pdk/node_modules/builtins": {
       "version": "5.1.0",
@@ -6460,9 +6421,7 @@
       }
     },
     "node_modules/@aws/pdk/node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "version": "4.0.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6500,13 +6459,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/es-abstract": {
       "version": "1.24.0",
@@ -6846,6 +6798,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@aws/pdk/node_modules/glob": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/globalthis": {
       "version": "1.0.4",
       "inBundle": true,
@@ -7034,6 +7004,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/@aws/pdk/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/is-async-function": {
       "version": "2.1.1",
@@ -7367,9 +7342,7 @@
       }
     },
     "node_modules/@aws/pdk/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -7421,6 +7394,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aws/pdk/node_modules/lines-and-columns": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/load-json-file": {
       "version": "6.2.0",
       "inBundle": true,
@@ -7431,16 +7412,6 @@
         "strip-bom": "^4.0.0",
         "type-fest": "^0.6.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -7571,16 +7542,6 @@
         "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
-    "node_modules/@aws/pdk/node_modules/mem/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/merge-stream": {
       "version": "2.0.0",
       "inBundle": true,
@@ -7592,6 +7553,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/minimatch": {
+      "version": "10.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@aws/pdk/node_modules/ms": {
@@ -7619,29 +7594,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/hosted-git-info": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
-      "integrity": "sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^7.5.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@aws/pdk/node_modules/normalize-path": {
@@ -7757,6 +7709,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws/pdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/p-locate": {
       "version": "4.1.0",
       "inBundle": true,
@@ -7766,22 +7732,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aws/pdk/node_modules/parse-json": {
@@ -7800,13 +7750,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/parse-json/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/parse-unit": {
       "version": "1.0.1",
@@ -7880,46 +7823,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@aws/pdk/node_modules/read-yaml-file": {
@@ -8017,52 +7920,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@aws/pdk/node_modules/safe-array-concat": {
@@ -8332,41 +8189,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "inBundle": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "inBundle": true,
@@ -8533,13 +8355,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@aws/pdk/node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/type-fest": {
       "version": "0.8.1",
@@ -8810,19 +8625,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/write-yaml-file": {
       "version": "5.0.0",
       "inBundle": true,
@@ -8865,6 +8667,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/@aws/pdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -8896,6 +8709,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -10091,6 +9905,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -11156,6 +10971,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -12365,7 +12181,6 @@
       "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.21.tgz",
       "integrity": "sha512-sWYAQ4j0CuTEqvcSrai6+Helnrkhc9dkUU2WZFlUiDPj7+eLGVN1jODH0a0Xmdohynhvu83URRwWJzPHE0veRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "^2.0.7",
         "individual": "^3.0.0"
@@ -12418,6 +12233,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -12538,6 +12354,7 @@
       "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
       "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "aws-cdk-lib": "^2.176.0",
         "constructs": "^10.0.5"
@@ -12730,7 +12547,8 @@
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
       "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -13056,8 +12874,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -13449,8 +13266,7 @@
     "node_modules/individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
-      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==",
-      "peer": true
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -13687,6 +13503,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -14514,8 +14331,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -14948,7 +14764,6 @@
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
       "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "minimist": "^1.2.5",
@@ -14968,7 +14783,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -14983,7 +14797,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
@@ -15311,7 +15124,6 @@
         "yargs"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "case": "^1.6.3",
@@ -15341,14 +15153,12 @@
     "node_modules/projen/node_modules/@iarna/toml": {
       "version": "2.2.5",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/projen/node_modules/@oozcitak/dom": {
       "version": "1.15.10",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/url": "1.0.4",
@@ -15362,7 +15172,6 @@
       "version": "1.0.8",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oozcitak/util": "8.3.8"
       },
@@ -15374,7 +15183,6 @@
       "version": "1.0.4",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/util": "8.3.8"
@@ -15387,7 +15195,6 @@
       "version": "8.3.8",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.0"
       }
@@ -15396,7 +15203,6 @@
       "version": "5.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15405,7 +15211,6 @@
       "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -15420,7 +15225,6 @@
       "version": "1.0.10",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -15428,20 +15232,17 @@
     "node_modules/projen/node_modules/array-timsort": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/brace-expansion": {
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -15450,7 +15251,6 @@
       "version": "1.6.3",
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -15459,7 +15259,6 @@
       "version": "4.1.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15475,7 +15274,6 @@
       "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -15489,7 +15287,6 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -15500,14 +15297,12 @@
     "node_modules/projen/node_modules/color-name": {
       "version": "1.1.4",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/comment-json": {
       "version": "4.2.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -15522,32 +15317,27 @@
     "node_modules/projen/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/conventional-changelog-config-spec": {
       "version": "2.1.0",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/core-util-is": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/escalade": {
       "version": "3.1.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15556,7 +15346,6 @@
       "version": "4.0.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -15568,20 +15357,17 @@
     "node_modules/projen/node_modules/fast-json-patch": {
       "version": "3.1.1",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/fs.realpath": {
       "version": "1.0.0",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/projen/node_modules/function-bind": {
       "version": "1.1.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15590,7 +15376,6 @@
       "version": "2.0.5",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -15599,7 +15384,6 @@
       "version": "8.1.0",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15618,7 +15402,6 @@
       "version": "5.1.6",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15630,7 +15413,6 @@
       "version": "4.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15639,7 +15421,6 @@
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15648,7 +15429,6 @@
       "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -15660,7 +15440,6 @@
       "version": "1.0.6",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15669,14 +15448,12 @@
     "node_modules/projen/node_modules/inherits": {
       "version": "2.0.4",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/projen/node_modules/ini": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15685,7 +15462,6 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -15694,7 +15470,6 @@
       "version": "2.14.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -15709,7 +15484,6 @@
       "version": "3.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15718,7 +15492,6 @@
       "version": "3.14.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -15731,7 +15504,6 @@
       "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -15743,7 +15515,6 @@
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15753,7 +15524,6 @@
       "version": "1.2.8",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15762,7 +15532,6 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -15771,7 +15540,6 @@
       "version": "1.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15779,13 +15547,11 @@
     "node_modules/projen/node_modules/path-parse": {
       "version": "1.0.7",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/projen/node_modules/rechoir": {
       "version": "0.6.2",
       "inBundle": true,
-      "peer": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -15797,7 +15563,6 @@
       "version": "1.6.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -15806,7 +15571,6 @@
       "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15815,7 +15579,6 @@
       "version": "1.22.8",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -15832,7 +15595,6 @@
       "version": "7.6.2",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15844,7 +15606,6 @@
       "version": "0.8.5",
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -15861,7 +15622,6 @@
       "version": "7.2.3",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15881,7 +15641,6 @@
       "version": "0.3.4",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -15896,14 +15655,12 @@
     "node_modules/projen/node_modules/sprintf-js": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/projen/node_modules/string-width": {
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15917,7 +15674,6 @@
       "version": "6.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15929,7 +15685,6 @@
       "version": "7.2.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -15941,7 +15696,6 @@
       "version": "1.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -15953,7 +15707,6 @@
       "version": "7.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -15969,14 +15722,12 @@
     "node_modules/projen/node_modules/wrappy": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/projen/node_modules/xmlbuilder2": {
       "version": "3.1.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oozcitak/dom": "1.15.10",
         "@oozcitak/infra": "1.0.8",
@@ -15991,7 +15742,6 @@
       "version": "5.0.8",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -16000,7 +15750,6 @@
       "version": "2.4.5",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16012,7 +15761,6 @@
       "version": "17.7.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -16030,7 +15778,6 @@
       "version": "21.1.1",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -16737,7 +16484,6 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "3"
       }
@@ -16747,7 +16493,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16848,6 +16593,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16930,6 +16676,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17309,6 +17056,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.17.tgz",
       "integrity": "sha512-8hQzQ/kMOIFbwOgPrm9Sf9rtFHpFUMy4HvN0yEB0spw14aYi0uT5xG5CE2DB9cd51GWNsz+DNO7se1kztHMKnw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## 事象
音声ロールプレイ開始後、NPC（AI側）の2回目以降の応答で AccessDeniedException が発生。 AgentCore Runtime（npc-conversation）からBedrock ConverseStream呼び出し時に aws-marketplace:ViewSubscriptions / Subscribe 権限不足でモデルアクセスが拒否されていた。

モデル: global.anthropic.claude-haiku-4-5-20251001-v1:0
実行ロール: NpcConversationAgentRunti-BCYbaK3D6zW3

## 原因
agentcore-runtime.ts の BedrockModelInvocation IAMポリシーに2つの不足があった。

inference-profile/* ARNの欠落: global.* 形式のcross-region inference profileモデルIDは foundation-model/* ではなく inference-profile/* のARNパターンで解決される。他のLambda関数（auth.ts, scoring-lambda.ts等）にはすべて含まれていたが、AgentCore Runtimeだけ抜けていた。

aws-marketplace 権限の欠落: サードパーティモデル（Anthropic等）を初めて呼び出す際、Bedrockが自動的にAWS Marketplaceサブスクリプションを開始する。この権限がないとサブスクリプションが失敗し、2回目以降の呼び出しで AccessDeniedException が発生する。