### PR TITLE
feat: ビデオ録画機能のオン/オフ設定を追加 (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ ATXDocumentation
 output
 .kiro/steering/atx-documentation.md
 frontend/tmp
+.playwright-mcp/

--- a/frontend/src/__tests__/components/MessageList.test.tsx
+++ b/frontend/src/__tests__/components/MessageList.test.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MessageList from "../../components/conversation/MessageList";
+import type { Scenario, Metrics } from "../../types/index";
+
+// i18nモック（キーをそのまま返すことで分岐を識別しやすくする）
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: { [key: string]: string } = {
+        "conversation.startQuestion": "商談を開始しますか？",
+        "conversation.startButton": "商談開始",
+        "conversation.startButtonNoRecording": "商談開始（録画なし）",
+        "conversation.cameraInitializing": "カメラ初期化中...",
+        "conversation.cameraInitializingMessage": "カメラを初期化しています...",
+        "conversation.cameraAccessFailed": "カメラへのアクセスに失敗しました",
+        "conversation.recordingDisabledMessage": "ビデオ録画はオフです",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+// dialogueEngineのgetSessionEndReasonをモック（セッション終了表示に使用）
+jest.mock("../../utils/dialogueEngine", () => ({
+  getSessionEndReason: () => "セッション終了理由",
+}));
+
+describe("MessageList - ビデオ録画オン/オフによる開始ボタンの挙動", () => {
+  const mockScenario: Scenario = {
+    id: "test-scenario",
+    title: "テストシナリオ",
+    description: "テスト用シナリオの説明",
+    difficulty: "normal",
+    industry: "IT",
+    npc: {
+      id: "npc-1",
+      name: "テスト太郎",
+      role: "部長",
+      company: "テスト株式会社",
+      personality: [],
+      avatar: "👤",
+      description: "",
+    },
+    initialMetrics: {
+      angerLevel: 1,
+      trustLevel: 1,
+      progressLevel: 1,
+    },
+    goals: [],
+  };
+
+  const mockMetrics: Metrics = {
+    angerLevel: 1,
+    trustLevel: 1,
+    progressLevel: 1,
+  };
+
+  const defaultProps = {
+    messages: [],
+    isProcessing: false,
+    sessionStarted: false,
+    sessionEnded: false,
+    currentMetrics: mockMetrics,
+    scenario: mockScenario,
+    onStartConversation: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("録画オン時（videoRecordingEnabled = true）", () => {
+    test("カメラ未初期化かつエラーなしの場合、開始ボタンは無効でカメラ初期化中ラベルになる", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={true}
+          isCameraInitialized={false}
+          cameraError={false}
+        />,
+      );
+
+      const button = screen.getByTestId("start-conversation-button");
+      expect(button).toBeDisabled();
+      expect(button).toHaveTextContent("カメラ初期化中...");
+    });
+
+    test("カメラ初期化完了の場合、開始ボタンは有効で通常の商談開始ラベルになる", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={true}
+          isCameraInitialized={true}
+          cameraError={false}
+        />,
+      );
+
+      const button = screen.getByTestId("start-conversation-button");
+      expect(button).toBeEnabled();
+      expect(button).toHaveTextContent("商談開始");
+    });
+
+    test("カメラエラーの場合、開始ボタンは有効で録画なしラベルになる", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={true}
+          isCameraInitialized={false}
+          cameraError={true}
+        />,
+      );
+
+      const button = screen.getByTestId("start-conversation-button");
+      expect(button).toBeEnabled();
+      expect(button).toHaveTextContent("商談開始（録画なし）");
+    });
+  });
+
+  describe("録画オフ時（videoRecordingEnabled = false）", () => {
+    test("カメラ初期化状態に関わらず開始ボタンは即有効で録画なしラベルになる", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={false}
+          isCameraInitialized={false}
+          cameraError={false}
+        />,
+      );
+
+      const button = screen.getByTestId("start-conversation-button");
+      expect(button).toBeEnabled();
+      expect(button).toHaveTextContent("商談開始（録画なし）");
+    });
+
+    test("録画オフを示すメッセージが表示される", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={false}
+        />,
+      );
+
+      expect(screen.getByText("ビデオ録画はオフです")).toBeInTheDocument();
+    });
+
+    test("録画オフ時はカメラ初期化中メッセージを表示しない", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          videoRecordingEnabled={false}
+          isCameraInitialized={false}
+          cameraError={false}
+        />,
+      );
+
+      expect(
+        screen.queryByText("カメラを初期化しています..."),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("videoRecordingEnabled未指定（デフォルト = 録画オン）", () => {
+    test("デフォルトでは録画オンとして扱われ、カメラ未初期化時はボタンが無効になる", () => {
+      render(
+        <MessageList
+          {...defaultProps}
+          isCameraInitialized={false}
+          cameraError={false}
+        />,
+      );
+
+      const button = screen.getByTestId("start-conversation-button");
+      expect(button).toBeDisabled();
+      expect(button).toHaveTextContent("カメラ初期化中...");
+    });
+  });
+});

--- a/frontend/src/__tests__/components/SessionSettingsPanel.test.tsx
+++ b/frontend/src/__tests__/components/SessionSettingsPanel.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SessionSettingsPanel from "../../components/conversation/SessionSettingsPanel";
+
+// i18nモック（キーをそのまま日本語訳に変換して返す）
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const translations: { [key: string]: string } = {
+        "conversation.settings.recordingOn": "ビデオ録画 ON",
+        "conversation.settings.recordingOff": "ビデオ録画 OFF",
+        "conversation.settings.recordingNote":
+          "※ 録画をオフにすると、カメラを使用せず、動画分析機能は利用できません",
+        "conversation.settings.recordingLockedNote":
+          "※ 録画設定は商談開始前のみ変更できます",
+        "conversation.audioSettings.outputOn": "音声出力 ON",
+        "conversation.audioSettings.outputOff": "音声出力 OFF",
+        "conversation.audioSettings.volume": `音量: ${options?.volume ?? ""}%`,
+        "conversation.audioSettings.speechRate": `読み上げ速度: ${options?.rate ?? ""}x`,
+        "conversation.audioSettings.npcResponseNote":
+          "※ NPCの応答が音声で再生されます",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+/**
+ * 録画トグルスイッチを取得（アクセシブル名で特定）
+ * MUIのSwitchは role="switch" としてレンダリングされ、ラベルテキストから
+ * アクセシブル名が算出される。日英のON/OFFラベルに対応。
+ */
+const getRecordingToggle = () =>
+  screen.getByRole("switch", {
+    name: /ビデオ録画 (ON|OFF)|Video Recording (ON|OFF)/,
+  });
+
+const queryRecordingToggle = () =>
+  screen.queryByRole("switch", {
+    name: /ビデオ録画 (ON|OFF)|Video Recording (ON|OFF)/,
+  });
+
+describe("SessionSettingsPanel - ビデオ録画トグル", () => {
+  const defaultProps = {
+    audioEnabled: true,
+    setAudioEnabled: jest.fn(),
+    audioVolume: 80,
+    setAudioVolume: jest.fn(),
+    speechRate: 1.0,
+    setSpeechRate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("setVideoRecordingEnabledが渡された場合、録画トグルが表示される", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+      />,
+    );
+
+    expect(getRecordingToggle()).toBeInTheDocument();
+  });
+
+  test("setVideoRecordingEnabledが渡されない場合、録画トグルは表示されない", () => {
+    render(<SessionSettingsPanel {...defaultProps} />);
+
+    expect(queryRecordingToggle()).not.toBeInTheDocument();
+  });
+
+  test("録画オン時はトグルがチェック済みになる", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+      />,
+    );
+
+    expect(getRecordingToggle()).toBeChecked();
+  });
+
+  test("録画オフ時はトグルが未チェックになる", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={false}
+        setVideoRecordingEnabled={jest.fn()}
+      />,
+    );
+
+    expect(getRecordingToggle()).not.toBeChecked();
+  });
+
+  test("トグル操作でsetVideoRecordingEnabledが呼ばれる", () => {
+    const setVideoRecordingEnabled = jest.fn();
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={setVideoRecordingEnabled}
+      />,
+    );
+
+    fireEvent.click(getRecordingToggle());
+    expect(setVideoRecordingEnabled).toHaveBeenCalledWith(false);
+  });
+
+  test("recordingSettingLocked=trueの場合、トグルは無効化される", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+        recordingSettingLocked={true}
+      />,
+    );
+
+    expect(getRecordingToggle()).toBeDisabled();
+  });
+
+  test("recordingSettingLocked=falseの場合、トグルは有効", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+        recordingSettingLocked={false}
+      />,
+    );
+
+    expect(getRecordingToggle()).toBeEnabled();
+  });
+
+  test("ロック時はロック用の注意書きが表示される", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+        recordingSettingLocked={true}
+      />,
+    );
+
+    expect(
+      screen.getByText("※ 録画設定は商談開始前のみ変更できます"),
+    ).toBeInTheDocument();
+  });
+
+  test("非ロック時は通常の注意書きが表示される", () => {
+    render(
+      <SessionSettingsPanel
+        {...defaultProps}
+        videoRecordingEnabled={true}
+        setVideoRecordingEnabled={jest.fn()}
+        recordingSettingLocked={false}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "※ 録画をオフにすると、カメラを使用せず、動画分析機能は利用できません",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/conversation/MessageList.tsx
+++ b/frontend/src/components/conversation/MessageList.tsx
@@ -1,9 +1,10 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useMemo } from "react";
 import { Box, Typography, Paper, LinearProgress, Button } from "@mui/material";
 import { Send as SendIcon } from "@mui/icons-material";
 import { Message, Metrics, Scenario } from "../../types/index";
 import type { SlideImageInfo } from "../../types/api";
 import { getSessionEndReason } from "../../utils/dialogueEngine";
+import { DEFAULT_VIDEO_RECORDING_ENABLED } from "../../utils/videoRecordingSettings";
 import { useTranslation } from "react-i18next";
 
 interface MessageListProps {
@@ -16,6 +17,8 @@ interface MessageListProps {
   onStartConversation: () => void;
   isCameraInitialized?: boolean;
   cameraError?: boolean;
+  /** ビデオ録画機能の有効/無効 */
+  videoRecordingEnabled?: boolean;
   /** スライド画像一覧（サムネイル表示用） */
   slideImages?: SlideImageInfo[];
   /** スライドサムネイルクリック時のコールバック */
@@ -35,12 +38,32 @@ const MessageList: React.FC<MessageListProps> = ({
   onStartConversation,
   isCameraInitialized = false,
   cameraError = false,
+  videoRecordingEnabled = DEFAULT_VIDEO_RECORDING_ENABLED,
   slideImages = [],
   onSlideClick,
 }) => {
   const { t } = useTranslation();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // 商談開始ボタンの有効化判定とラベルを算出
+  // 録画オフの場合は常に開始可能（カメラ初期化を待たない）
+  // 録画オンの場合はカメラ初期化完了またはカメラエラー時のみ開始可能
+  const canStart = !videoRecordingEnabled || isCameraInitialized || cameraError;
+
+  // ボタンラベルの決定（aria-labelと表示テキストで共用）
+  const startButtonLabel = useMemo(() => {
+    if (!videoRecordingEnabled) {
+      return t("conversation.startButtonNoRecording");
+    }
+    if (isCameraInitialized) {
+      return t("conversation.startButton");
+    }
+    if (cameraError) {
+      return t("conversation.startButtonNoRecording");
+    }
+    return t("conversation.cameraInitializing");
+  }, [videoRecordingEnabled, isCameraInitialized, cameraError, t]);
 
   // メッセージ自動スクロール（親要素のスクロールを防止）
   useEffect(() => {
@@ -77,7 +100,20 @@ const MessageList: React.FC<MessageListProps> = ({
             {scenario.description}
           </Typography>
 
-          {!isCameraInitialized && !cameraError && (
+          {/* 録画オフ時のメッセージ */}
+          {!videoRecordingEnabled && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 2 }}
+              role="status"
+            >
+              {t("conversation.recordingDisabledMessage")}
+            </Typography>
+          )}
+
+          {/* 録画オン時のカメラ初期化中メッセージ */}
+          {videoRecordingEnabled && !isCameraInitialized && !cameraError && (
             <Typography
               variant="caption"
               color="warning.main"
@@ -89,7 +125,8 @@ const MessageList: React.FC<MessageListProps> = ({
             </Typography>
           )}
 
-          {cameraError && (
+          {/* 録画オン時のカメラアクセス失敗メッセージ */}
+          {videoRecordingEnabled && cameraError && (
             <Typography
               variant="caption"
               color="error.main"
@@ -105,24 +142,14 @@ const MessageList: React.FC<MessageListProps> = ({
             size="large"
             onClick={onStartConversation}
             startIcon={<SendIcon />}
-            disabled={!isCameraInitialized && !cameraError}
+            disabled={!canStart}
             data-testid="start-conversation-button"
-            aria-label={
-              isCameraInitialized
-                ? t("conversation.startButton")
-                : cameraError
-                  ? t("conversation.startButtonNoRecording")
-                  : t("conversation.cameraInitializing")
-            }
+            aria-label={startButtonLabel}
             sx={{
-              opacity: (isCameraInitialized || cameraError) ? 1 : 0.6,
+              opacity: canStart ? 1 : 0.6,
             }}
           >
-            {isCameraInitialized
-              ? t("conversation.startButton")
-              : cameraError
-                ? t("conversation.startButtonNoRecording")
-                : t("conversation.cameraInitializing")}
+            {startButtonLabel}
           </Button>
         </Box>
       ) : (

--- a/frontend/src/components/conversation/SessionSettingsPanel.tsx
+++ b/frontend/src/components/conversation/SessionSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import {
   Card,
   CardContent,
@@ -13,6 +13,8 @@ import {
   VolumeOff as VolumeOffIcon,
   Person as PersonIcon,
   PersonOff as PersonOffIcon,
+  Videocam as VideocamIcon,
+  VideocamOff as VideocamOffIcon,
 } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 
@@ -27,6 +29,11 @@ interface SessionSettingsPanelProps {
   avatarVisible?: boolean;
   setAvatarVisible?: (visible: boolean) => void;
   avatarEnabled?: boolean;
+  // ビデオ録画トグル（商談開始前のみ変更可能）
+  videoRecordingEnabled?: boolean;
+  setVideoRecordingEnabled?: (enabled: boolean) => void;
+  // 録画設定の変更可否（商談開始後はロック）
+  recordingSettingLocked?: boolean;
 }
 
 /**
@@ -43,64 +50,63 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
   avatarVisible,
   setAvatarVisible,
   avatarEnabled,
+  videoRecordingEnabled,
+  setVideoRecordingEnabled,
+  recordingSettingLocked = false,
 }) => {
-  const { t, i18n } = useTranslation();
-  const [ready, setReady] = useState<boolean>(i18n.isInitialized);
-
-  // i18n初期化の完了を待つ（イベント駆動）
-  useEffect(() => {
-    if (i18n.isInitialized) {
-      // 既に初期化済みの場合は初期値で対応済みなのでリスナーのみ登録
-      return;
-    }
-    const handleInitialized = () => setReady(true);
-    i18n.on('initialized', handleInitialized);
-    return () => { i18n.off('initialized', handleInitialized); };
-  }, [i18n]);
-
-  // フォールバックテキスト（翻訳が読み込まれるまでの一時的なテキスト）
-  // ブラウザの言語設定に基づいてフォールバック言語を選択
-  const getDefaultText = (key: string): string => {
-    const browserLang = navigator.language.startsWith('ja') ? 'ja' : 'en';
-    const defaults: Record<string, Record<string, string>> = {
-      ja: {
-        "conversation.audioSettings.title": "音声設定",
-        "conversation.audioSettings.outputOn": "音声出力 ON",
-        "conversation.audioSettings.outputOff": "音声出力 OFF",
-        "conversation.audioSettings.volume": `音量: ${audioVolume}%`,
-        "conversation.audioSettings.speechRate": `読み上げ速度: ${speechRate.toFixed(1)}x`,
-        "conversation.audioSettings.npcResponseNote": "※ NPCの応答が音声で再生されます",
-        "conversation.settings.title": "設定",
-        "conversation.settings.avatarOn": "3Dアバター表示 ON",
-        "conversation.settings.avatarOff": "3Dアバター表示 OFF",
-      },
-      en: {
-        "conversation.audioSettings.title": "Audio Settings",
-        "conversation.audioSettings.outputOn": "Audio Output ON",
-        "conversation.audioSettings.outputOff": "Audio Output OFF",
-        "conversation.audioSettings.volume": `Volume: ${audioVolume}%`,
-        "conversation.audioSettings.speechRate": `Speech Rate: ${speechRate.toFixed(1)}x`,
-        "conversation.audioSettings.npcResponseNote": "※ NPC responses will be played as audio",
-        "conversation.settings.title": "Settings",
-        "conversation.settings.avatarOn": "3D Avatar ON",
-        "conversation.settings.avatarOff": "3D Avatar OFF",
-      },
-    };
-    return defaults[browserLang]?.[key] || key;
-  };
-
-  // 翻訳関数のラッパー - 初期化前はデフォルトテキストを返す
-  const translate = (
-    key: string,
-    options?: Record<string, unknown>,
-  ): string => {
-    if (!ready) return getDefaultText(key);
-    return t(key, options);
-  };
+  // i18nリソースは静的にバンドルされ initImmediate:false で同期初期化されるため、
+  // 初回レンダリング時点で t() は正しい翻訳を返す。フォールバック機構は不要であり、
+  // 翻訳テキストは ja.json / en.json を単一の真実の源とする（二重管理を排除）。
+  const { t } = useTranslation();
 
   return (
     <Card sx={{ mb: 2 }}>
       <CardContent>
+        {/* ビデオ録画トグル（商談開始前のみ変更可能） */}
+        {setVideoRecordingEnabled && (
+          <Box sx={{ mb: 2 }} data-testid="video-recording-setting">
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={videoRecordingEnabled ?? true}
+                  onChange={(e) => setVideoRecordingEnabled(e.target.checked)}
+                  color="primary"
+                  disabled={recordingSettingLocked}
+                  inputProps={{
+                    // アクセシブル名（ON/OFF・日英対応）。テストもこの名前で要素を特定する
+                    "aria-label": videoRecordingEnabled ?? true
+                      ? t("conversation.settings.recordingOn")
+                      : t("conversation.settings.recordingOff"),
+                  }}
+                />
+              }
+              label={
+                <Box display="flex" alignItems="center">
+                  {videoRecordingEnabled ?? true ? (
+                    <VideocamIcon fontSize="small" sx={{ mr: 1 }} />
+                  ) : (
+                    <VideocamOffIcon fontSize="small" sx={{ mr: 1 }} />
+                  )}
+                  <Typography variant="body2">
+                    {videoRecordingEnabled ?? true
+                      ? t("conversation.settings.recordingOn")
+                      : t("conversation.settings.recordingOff")}
+                  </Typography>
+                </Box>
+              }
+            />
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", ml: 0.5 }}
+            >
+              {recordingSettingLocked
+                ? t("conversation.settings.recordingLockedNote")
+                : t("conversation.settings.recordingNote")}
+            </Typography>
+          </Box>
+        )}
+
         {/* アバター表示トグル（シナリオでアバターが有効な場合のみ表示） */}
         {avatarEnabled && setAvatarVisible && (
           <Box sx={{ mb: 2 }}>
@@ -121,8 +127,8 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
                   )}
                   <Typography variant="body2">
                     {avatarVisible
-                      ? translate("conversation.settings.avatarOn")
-                      : translate("conversation.settings.avatarOff")}
+                      ? t("conversation.settings.avatarOn")
+                      : t("conversation.settings.avatarOff")}
                   </Typography>
                 </Box>
               }
@@ -148,8 +154,8 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
               )}
               <Typography variant="body2">
                 {audioEnabled
-                  ? translate("conversation.audioSettings.outputOn")
-                  : translate("conversation.audioSettings.outputOff")}
+                  ? t("conversation.audioSettings.outputOn")
+                  : t("conversation.audioSettings.outputOff")}
               </Typography>
             </Box>
           }
@@ -159,7 +165,7 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
           <>
             <Box mt={2}>
               <Typography variant="body2" gutterBottom>
-                {translate("conversation.audioSettings.volume", {
+                {t("conversation.audioSettings.volume", {
                   volume: audioVolume,
                 })}
               </Typography>
@@ -176,7 +182,7 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
 
             <Box mt={2}>
               <Typography variant="body2" gutterBottom>
-                {translate("conversation.audioSettings.speechRate", {
+                {t("conversation.audioSettings.speechRate", {
                   rate: speechRate.toFixed(1),
                 })}
               </Typography>
@@ -205,7 +211,7 @@ const SessionSettingsPanel: React.FC<SessionSettingsPanelProps> = ({
           color="text.secondary"
           sx={{ display: "block", mt: 1 }}
         >
-          {translate("conversation.audioSettings.npcResponseNote")}
+          {t("conversation.audioSettings.npcResponseNote")}
         </Typography>
       </CardContent>
     </Card>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -227,6 +227,7 @@
     "cameraInitializing": "Initializing camera...",
     "cameraInitializingMessage": "📹 Initializing camera. Please wait...",
     "cameraAccessFailed": "⚠️ Failed to access camera. You can start the conversation without recording.",
+    "recordingDisabledMessage": "📹 Video recording is off. The conversation will start without recording.",
     "realTimeEvaluation": "Real-time Evaluation",
     "angerMeterConversation": "Anger Meter",
     "trustLevelConversation": "Trust Level",
@@ -248,7 +249,11 @@
     "settings": {
       "title": "Settings",
       "avatarOn": "3D Avatar ON",
-      "avatarOff": "3D Avatar OFF"
+      "avatarOff": "3D Avatar OFF",
+      "recordingOn": "Video Recording ON",
+      "recordingOff": "Video Recording OFF",
+      "recordingNote": "* When recording is off, the camera is not used and video analysis is unavailable",
+      "recordingLockedNote": "* Recording settings can only be changed before the conversation starts"
     }
   },
   "metrics": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -227,6 +227,7 @@
     "cameraInitializing": "カメラ初期化中...",
     "cameraInitializingMessage": "📹 カメラを初期化しています。しばらくお待ちください...",
     "cameraAccessFailed": "⚠️ カメラへのアクセスに失敗しました。録画なしで商談を開始できます。",
+    "recordingDisabledMessage": "📹 ビデオ録画はオフです。録画なしで商談を開始します。",
     "realTimeEvaluation": "リアルタイム評価",
     "angerMeterConversation": "怒りメーター",
     "trustLevelConversation": "信頼度",
@@ -248,7 +249,11 @@
     "settings": {
       "title": "設定",
       "avatarOn": "3Dアバター表示 ON",
-      "avatarOff": "3Dアバター表示 OFF"
+      "avatarOff": "3Dアバター表示 OFF",
+      "recordingOn": "ビデオ録画 ON",
+      "recordingOff": "ビデオ録画 OFF",
+      "recordingNote": "※ 録画をオフにすると、カメラを使用せず、動画分析機能は利用できません",
+      "recordingLockedNote": "※ 録画設定は商談開始前のみ変更できます"
     }
   },
   "metrics": {

--- a/frontend/src/pages/ConversationPage.tsx
+++ b/frontend/src/pages/ConversationPage.tsx
@@ -29,6 +29,10 @@ import {
   mergeGoalStatus,
 } from "../utils/goalUtils";
 import VideoManager from "../components/recording/v2/VideoManager";
+import {
+  loadVideoRecordingEnabled,
+  saveVideoRecordingEnabled,
+} from "../utils/videoRecordingSettings";
 
 // 分割したコンポーネントをインポート
 import ConversationHeader from "../components/conversation/ConversationHeader";
@@ -192,6 +196,23 @@ const ConversationPage: React.FC = () => {
   const [isCameraInitialized, setIsCameraInitialized] = useState<boolean>(false);
   // カメラエラー状態管理
   const [cameraError, setCameraError] = useState<boolean>(false);
+  // ビデオ録画機能のオン/オフ設定（localStorageで永続化、デフォルトはオン）
+  const [videoRecordingEnabled, setVideoRecordingEnabled] = useState<boolean>(
+    loadVideoRecordingEnabled,
+  );
+
+  // ビデオ録画設定の変更をlocalStorageに永続化
+  useEffect(() => {
+    saveVideoRecordingEnabled(videoRecordingEnabled);
+
+    // 録画を無効化した場合、VideoManagerがアンマウントされてカメラ初期化コールバックが
+    // 呼ばれなくなるため、カメラ関連stateを明示的にリセットして状態の意味を一貫させる。
+    // （録画無効時はカメラを使用しないため、初期化済み・エラーのいずれでもない状態に戻す）
+    if (!videoRecordingEnabled) {
+      setIsCameraInitialized(false);
+      setCameraError(false);
+    }
+  }, [videoRecordingEnabled]);
 
   // 新レイアウト用state
   const [rightPanelsVisible, setRightPanelsVisible] = useState<boolean>(true);
@@ -1018,9 +1039,17 @@ const ConversationPage: React.FC = () => {
       };
 
       // 録画アップロード完了を待ってから遷移
-      await waitForRecordingUpload();
+      // ビデオ録画が無効な場合は待機をスキップ
+      if (videoRecordingEnabled) {
+        await waitForRecordingUpload();
+      }
 
       // セッション分析を非同期で開始（Step Functions）
+      // 注意: 録画無効時もセッション分析は起動するが、これは意図的な設計。
+      // バックエンドの動画分析ステップ（sessionAnalysis/video_handler.py）は
+      // S3に動画が存在しない場合を正常系として扱い、videoSkipReason="no_video"で
+      // スキップする。そのため録画オフでもエラーや無駄なNova呼び出し（課金）は発生せず、
+      // 会話ログベースのフィードバック分析は通常どおり実行される。
       try {
         const apiService = ApiService.getInstance();
         await apiService.startSessionAnalysis(
@@ -1047,6 +1076,7 @@ const ConversationPage: React.FC = () => {
       goalScore,
       sessionId,
       i18n.language,
+      videoRecordingEnabled,
     ],
   );
 
@@ -1345,30 +1375,33 @@ const ConversationPage: React.FC = () => {
         )}
 
         {/* カメラプレビュー（左上、メトリクスの下） */}
-        <Box
-          sx={{
-            position: "absolute",
-            top: metricsVisible && sessionStarted ? 110 : 12,
-            left: 12,
-            zIndex: 10,
-            width: 180,
-            borderRadius: 2,
-            overflow: "hidden",
-            boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
-            transition: "top 0.2s ease",
-            "@media (prefers-reduced-motion: reduce)": {
-              transition: "none",
-            },
-          }}
-        >
-          <VideoManager
-            ref={undefined}
-            sessionId={sessionId}
-            sessionStarted={sessionStarted}
-            sessionEnded={sessionEnded}
-            onCameraInitialized={handleCameraInitialized}
-          />
-        </Box>
+        {videoRecordingEnabled && (
+          <Box
+            data-testid="video-manager-container"
+            sx={{
+              position: "absolute",
+              top: metricsVisible && sessionStarted ? 110 : 12,
+              left: 12,
+              zIndex: 10,
+              width: 180,
+              borderRadius: 2,
+              overflow: "hidden",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+              transition: "top 0.2s ease",
+              "@media (prefers-reduced-motion: reduce)": {
+                transition: "none",
+              },
+            }}
+          >
+            <VideoManager
+              ref={undefined}
+              sessionId={sessionId}
+              sessionStarted={sessionStarted}
+              sessionEnded={sessionEnded}
+              onCameraInitialized={handleCameraInitialized}
+            />
+          </Box>
+        )}
 
         {/* アバターステージ（中央） — CR-009: AvatarProviderを条件分岐外に配置し再マウント防止 */}
         {avatarVisible && (
@@ -1460,6 +1493,7 @@ const ConversationPage: React.FC = () => {
             onStartConversation={startConversation}
             isCameraInitialized={isCameraInitialized}
             cameraError={cameraError}
+            videoRecordingEnabled={videoRecordingEnabled}
             slideImages={slideImages}
             onSlideClick={(idx) => { setCurrentSlideIndex(idx); setIsSlideZoomOpen(true); }}
           />
@@ -1523,6 +1557,9 @@ const ConversationPage: React.FC = () => {
             avatarVisible={avatarVisible}
             setAvatarVisible={setAvatarVisible}
             avatarEnabled={enableAvatar}
+            videoRecordingEnabled={videoRecordingEnabled}
+            setVideoRecordingEnabled={setVideoRecordingEnabled}
+            recordingSettingLocked={sessionStarted}
           />
         </DialogContent>
       </Dialog>

--- a/frontend/src/tests/e2e/video-recording-toggle.spec.ts
+++ b/frontend/src/tests/e2e/video-recording-toggle.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * E2Eテスト: ビデオ録画機能のオン/オフ設定
+ *
+ * GitHub Issue #54「ビデオ録画機能のオン/オフ設定の追加」のE2Eテスト
+ * dev環境（CloudFront）への接続を伴う統合テスト
+ *
+ * 検証観点:
+ * 1. 設定モーダルに録画トグルが表示されること
+ * 2. 録画オフ時にカメラプレビュー（VideoManager の video 要素）が非表示になること
+ * 3. 録画オフ時に開始ボタンがカメラ初期化を待たず即有効化されること
+ * 4. 録画設定がlocalStorageに永続化されること（リロード後も保持）
+ * 5. セッション開始後は録画設定がロックされること
+ *
+ * 注意: セレクターはデプロイ済み環境で安定的に動作する aria-label / role ベースを使用する
+ * （data-testid はビルド・デプロイ後にのみ反映されるため、ここでは依存しない）
+ */
+import { test, expect, Page, Locator } from "@playwright/test";
+import { login, navigateToScenarioSelect } from "./helpers";
+
+// 設定モーダルを開くボタン（i18n: ⚙️アイコン、日英のaria-labelに対応）
+const SETTINGS_BUTTON_SELECTOR =
+  'button[aria-label="設定を開く"], button[aria-label="Open settings"]';
+
+/**
+ * 録画トグルスイッチを取得
+ * MUIのSwitchは role="switch" の input 要素としてレンダリングされ、
+ * FormControlLabel のラベルテキストからアクセシブル名が算出される。
+ * ラベルはi18nでON/OFF・日英により変化するため、すべてのパターンに対応する。
+ *
+ * @param page Playwrightのページオブジェクト
+ */
+function getRecordingToggle(page: Page): Locator {
+  return page.getByRole("switch", {
+    name: /ビデオ録画 (ON|OFF)|Video Recording (ON|OFF)/,
+  });
+}
+
+/**
+ * カメラプレビュー（VideoManager がレンダリングする video 要素）を取得
+ * 録画オン時のみ会話画面に video 要素が表示される。
+ *
+ * @param page Playwrightのページオブジェクト
+ */
+function getCameraPreview(page: Page): Locator {
+  return page.locator("main video");
+}
+
+// テスト実行前の共通セットアップ
+test.beforeEach(async ({ page }) => {
+  await login(page);
+});
+
+/**
+ * シナリオ選択から会話ページへ遷移するヘルパー
+ *
+ * @param page Playwrightのページオブジェクト
+ */
+async function navigateToConversationPage(page: Page): Promise<void> {
+  await navigateToScenarioSelect(page);
+  const startButton = page
+    .locator('button:has-text("このシナリオで開始")')
+    .first();
+  await expect(startButton).toBeVisible();
+  await startButton.click();
+  await page.waitForURL(/\/conversation\//);
+}
+
+/**
+ * 設定モーダルを開くヘルパー
+ *
+ * @param page Playwrightのページオブジェクト
+ */
+async function openSettingsModal(page: Page): Promise<void> {
+  const settingsButton = page.locator(SETTINGS_BUTTON_SELECTOR).first();
+  await expect(settingsButton).toBeVisible({ timeout: 15000 });
+  await settingsButton.click();
+
+  // 設定ダイアログが表示されるまで待機
+  const settingsDialog = page.locator('[role="dialog"]');
+  await expect(settingsDialog.first()).toBeVisible({ timeout: 10000 });
+
+  // 録画トグルが表示されるまで待機
+  await expect(getRecordingToggle(page)).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("ビデオ録画オン/オフ設定", () => {
+  test.describe("設定パネルの表示", () => {
+    test("設定モーダルに録画トグルが表示されること", async ({ page }) => {
+      // 既定状態（録画オン）から開始するため設定をクリア
+      await navigateToScenarioSelect(page);
+      await page.evaluate(() =>
+        window.localStorage.removeItem("videoRecordingEnabled"),
+      );
+
+      await navigateToConversationPage(page);
+      await openSettingsModal(page);
+
+      // 録画トグルスイッチが表示されていることを確認
+      const recordingToggle = getRecordingToggle(page);
+      await expect(recordingToggle).toBeVisible();
+
+      // 既定では録画オン（チェック済み）であることを確認
+      await expect(recordingToggle).toBeChecked();
+    });
+  });
+
+  test.describe("録画オフ時の挙動", () => {
+    test("録画をオフにするとカメラプレビューが非表示になること", async ({
+      page,
+    }) => {
+      // 既定状態（録画オン）から開始するため設定をクリア
+      await navigateToScenarioSelect(page);
+      await page.evaluate(() =>
+        window.localStorage.removeItem("videoRecordingEnabled"),
+      );
+
+      await navigateToConversationPage(page);
+
+      // 既定（録画オン）ではカメラプレビュー（video要素）が存在する
+      const cameraPreview = getCameraPreview(page);
+      await expect(cameraPreview).toHaveCount(1, { timeout: 10000 });
+
+      // 設定モーダルを開いて録画をオフに切り替え
+      await openSettingsModal(page);
+      const recordingToggle = getRecordingToggle(page);
+      await recordingToggle.uncheck();
+      await expect(recordingToggle).not.toBeChecked();
+
+      // モーダルを閉じる（Escapeキー）
+      await page.keyboard.press("Escape");
+
+      // カメラプレビュー（video要素）がDOMから消えることを確認
+      await expect(cameraPreview).toHaveCount(0, { timeout: 10000 });
+    });
+
+    test("録画オフ時は開始ボタンがカメラ初期化を待たず即有効になること", async ({
+      page,
+    }) => {
+      // 事前にlocalStorageで録画オフを設定（カメラ初期化を一切待たない状態を作る）
+      await page.addInitScript(() => {
+        window.localStorage.setItem("videoRecordingEnabled", "false");
+      });
+
+      await navigateToConversationPage(page);
+
+      // 開始ボタンが即座に有効化されることを確認（カメラ初期化待ちが発生しない）
+      const startButton = page.locator(
+        '[data-testid="start-conversation-button"]',
+      );
+      await expect(startButton).toBeVisible({ timeout: 15000 });
+      await expect(startButton).toBeEnabled({ timeout: 5000 });
+
+      // ボタンラベルが「録画なし」表記になっていることを確認（日英対応）
+      const buttonText = (await startButton.textContent()) || "";
+      expect(
+        buttonText.includes("録画なし") ||
+        buttonText.includes("No Recording"),
+      ).toBeTruthy();
+
+      // カメラプレビュー（video要素）が表示されていないことを確認
+      await expect(getCameraPreview(page)).toHaveCount(0);
+    });
+  });
+
+  test.describe("設定の永続化", () => {
+    test("録画オフ設定がリロード後も保持されること", async ({ page }) => {
+      // 既定状態（録画オン）から開始するため設定をクリア
+      await navigateToScenarioSelect(page);
+      await page.evaluate(() =>
+        window.localStorage.removeItem("videoRecordingEnabled"),
+      );
+
+      await navigateToConversationPage(page);
+
+      // 録画をオフに切り替え
+      await openSettingsModal(page);
+      const recordingToggle = getRecordingToggle(page);
+      await recordingToggle.uncheck();
+      await expect(recordingToggle).not.toBeChecked();
+
+      // localStorageに永続化されていることを確認
+      const storedValue = await page.evaluate(() =>
+        window.localStorage.getItem("videoRecordingEnabled"),
+      );
+      expect(storedValue).toBe("false");
+
+      // ページをリロード（addInitScriptを使わないため設定は保持される）
+      await page.reload();
+      await page.waitForURL(/\/conversation\//);
+
+      // リロード後、カメラプレビュー（video要素）が非表示のままであることを確認
+      await expect(getCameraPreview(page)).toHaveCount(0, { timeout: 10000 });
+
+      // 設定モーダルを再度開き、トグルがオフのままであることを確認
+      await openSettingsModal(page);
+      await expect(getRecordingToggle(page)).not.toBeChecked();
+    });
+  });
+
+  test.describe("セッション開始後の設定ロック", () => {
+    test("セッション開始後は録画トグルが無効化されること", async ({ page }) => {
+      // 録画オフにして、カメラ初期化を待たず即座にセッション開始できる状態にする
+      await page.addInitScript(() => {
+        window.localStorage.setItem("videoRecordingEnabled", "false");
+      });
+
+      await navigateToConversationPage(page);
+
+      // セッションを開始
+      const startButton = page.locator(
+        '[data-testid="start-conversation-button"]',
+      );
+      await expect(startButton).toBeEnabled({ timeout: 15000 });
+      await startButton.click();
+
+      // セッション開始を確認（セッション終了ボタンの表示）
+      const endButton = page
+        .locator(
+          'button:has-text("セッション終了"), button:has-text("商談終了"), button:has-text("End Conversation")',
+        )
+        .first();
+      await expect(endButton).toBeVisible({ timeout: 30000 });
+
+      // 設定モーダルを開く
+      await openSettingsModal(page);
+
+      // セッション開始後は録画トグルが無効化（disabled）されていることを確認
+      await expect(getRecordingToggle(page)).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/videoRecordingSettings.test.ts
+++ b/frontend/src/utils/__tests__/videoRecordingSettings.test.ts
@@ -1,0 +1,77 @@
+import {
+  loadVideoRecordingEnabled,
+  saveVideoRecordingEnabled,
+  DEFAULT_VIDEO_RECORDING_ENABLED,
+} from "../videoRecordingSettings";
+
+describe("videoRecordingSettings", () => {
+  // 各テスト前にlocalStorageとconsole.warnのモックをリセット
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  describe("loadVideoRecordingEnabled", () => {
+    test("未設定の場合はデフォルト値（true）を返す", () => {
+      expect(loadVideoRecordingEnabled()).toBe(DEFAULT_VIDEO_RECORDING_ENABLED);
+      expect(loadVideoRecordingEnabled()).toBe(true);
+    });
+
+    test('"true"が保存されている場合はtrueを返す', () => {
+      localStorage.setItem("videoRecordingEnabled", "true");
+      expect(loadVideoRecordingEnabled()).toBe(true);
+    });
+
+    test('"false"が保存されている場合はfalseを返す', () => {
+      localStorage.setItem("videoRecordingEnabled", "false");
+      expect(loadVideoRecordingEnabled()).toBe(false);
+    });
+
+    test("不正な値の場合はfalse扱い（=true以外）になる", () => {
+      localStorage.setItem("videoRecordingEnabled", "invalid");
+      expect(loadVideoRecordingEnabled()).toBe(false);
+    });
+
+    test("localStorageが例外を投げる場合はデフォルト値にフォールバックする", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => { });
+      jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("localStorage unavailable");
+      });
+
+      expect(loadVideoRecordingEnabled()).toBe(DEFAULT_VIDEO_RECORDING_ENABLED);
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("saveVideoRecordingEnabled", () => {
+    test("trueを保存できる", () => {
+      saveVideoRecordingEnabled(true);
+      expect(localStorage.getItem("videoRecordingEnabled")).toBe("true");
+    });
+
+    test("falseを保存できる", () => {
+      saveVideoRecordingEnabled(false);
+      expect(localStorage.getItem("videoRecordingEnabled")).toBe("false");
+    });
+
+    test("localStorageが例外を投げても例外を伝播させない", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => { });
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("localStorage unavailable");
+      });
+
+      expect(() => saveVideoRecordingEnabled(false)).not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("保存と読み込みの往復", () => {
+    test("保存した値を正しく読み込める", () => {
+      saveVideoRecordingEnabled(false);
+      expect(loadVideoRecordingEnabled()).toBe(false);
+
+      saveVideoRecordingEnabled(true);
+      expect(loadVideoRecordingEnabled()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/videoRecordingSettings.ts
+++ b/frontend/src/utils/videoRecordingSettings.ts
@@ -1,0 +1,57 @@
+/**
+ * ビデオ録画設定の永続化ユーティリティ
+ *
+ * localStorageを介してビデオ録画機能のオン/オフ設定を読み書きする。
+ * Safariプライベートモードやストレージ無効環境での例外を考慮し、
+ * すべてのアクセスをtry-catchで保護する。
+ */
+
+/** localStorageのキー名 */
+const STORAGE_KEY = "videoRecordingEnabled";
+
+/**
+ * ビデオ録画設定のデフォルト値（true = 録画オン）
+ * 既存動作の維持のため、未設定時は録画オンとする。
+ * デフォルト値の単一の真実の源（Single Source of Truth）。
+ */
+export const DEFAULT_VIDEO_RECORDING_ENABLED = true;
+
+/**
+ * ビデオ録画設定をlocalStorageから読み込む
+ *
+ * @returns 録画が有効な場合はtrue。未設定または読み込み失敗時はデフォルト値
+ */
+export function loadVideoRecordingEnabled(): boolean {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    // 未設定（null）の場合はデフォルト値を返す（既存動作を維持）
+    if (saved === null) {
+      return DEFAULT_VIDEO_RECORDING_ENABLED;
+    }
+    return saved === "true";
+  } catch (error) {
+    // localStorageが利用できない環境（プライベートモード等）ではデフォルト値にフォールバック
+    console.warn(
+      "ビデオ録画設定の読み込みに失敗しました。デフォルト値を使用します。 / Failed to load video recording setting, using default.",
+      error,
+    );
+    return DEFAULT_VIDEO_RECORDING_ENABLED;
+  }
+}
+
+/**
+ * ビデオ録画設定をlocalStorageに保存する
+ *
+ * @param enabled 録画を有効にする場合はtrue
+ */
+export function saveVideoRecordingEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch (error) {
+    // 保存失敗時もアプリの動作は継続する（設定が永続化されないだけ）
+    console.warn(
+      "ビデオ録画設定の保存に失敗しました。 / Failed to save video recording setting.",
+      error,
+    );
+  }
+}


### PR DESCRIPTION
## 概要

ビデオ録画機能のオン/オフを切り替える設定を追加しました。録画が不要なユーザーが録画をオフにでき、録画関連処理（カメラ起動・録画・S3アップロード待機）を完全にスキップできます。

Closes #54

## 変更内容

### 機能
- セッション設定パネルに **ビデオ録画オン/オフのトグルスイッチ** を追加
- 録画オフ時は `VideoManager` を非マウント化し、カメラ起動・録画・アップロード待機をすべてスキップ
- 録画状態に応じて商談開始ボタンのラベル・有効化を制御（録画オフ時はカメラ初期化を待たず即開始可能）
- 録画設定を **localStorage に永続化**（デフォルトはオン＝既存動作を維持）
- 商談開始後は録画設定をロック（録画整合性のため）
- 開始画面に録画状態を表示（録画オフ時のメッセージ）

### リファクタリング・品質改善
- 録画設定の永続化を専用ユーティリティ `videoRecordingSettings.ts` に集約（try-catch保護、デフォルト値のSSoT化）
- 録画無効化時にカメラ関連stateを明示リセットし状態の一貫性を確保
- `MessageList` のボタン算出ロジックをJSX内IIFEからコンポーネント本体へ移動
- `SessionSettingsPanel` のi18nフォールバック二重管理を解消し `t()` 直接利用に統一

## UI上の表示

- 録画オン（デフォルト）: 従来どおりカメラプレビュー表示・録画実行
- 録画オフ: カメラプレビュー非表示・「商談開始（録画なし）」ボタンが即有効

## テスト

- **ユニットテスト 25件追加**（Jest + RTL）
  - `MessageList`: 録画オン/オフ/未指定の開始ボタン分岐（7件）
  - `SessionSettingsPanel`: トグル表示・状態・ロック・注意書き（9件）
  - `videoRecordingSettings`: 読み書き・デフォルト・localStorage例外フォールバック（9件）
- **E2Eテスト 5件追加**（Playwright, dev環境）
  - 設定パネルのトグル表示 / 録画オフ時のプレビュー非表示 / 開始ボタン即有効 / 設定の永続化 / セッション開始後のロック

### 検証結果
- ユニットテスト: 196件全合格（新規25件含む）
- E2Eテスト（chromium, dev環境）: 5件全合格
- ESLint: エラーなし
- i18n整合性チェック: 合格
- TypeScript型チェック: 本変更による新規エラーなし

## ブロックした機能 / 留意点

- 録画オフでもセッション分析は起動するが、バックエンド（`sessionAnalysis/video_handler.py`）が動画キー不在を正常系（`videoSkipReason="no_video"`）として処理するため、エラーや無駄なNova課金は発生しない（コードコメントで意図を明示）
