### PR TITLE
fix: リアルタイムスコアリングのトークン不足とセッション録画のアップロード制限を修正

### DIFF
--- a/cdk/agents/realtime-scoring/agent.py
+++ b/cdk/agents/realtime-scoring/agent.py
@@ -206,7 +206,12 @@ def handle_invocation(payload: Dict[str, Any]) -> Dict[str, Any]:
             model_id=BEDROCK_MODEL,
             region_name=AWS_REGION,
             temperature=0.3,
-            max_tokens=1024,
+            # ScoringResult（8フィールド: スコア3 + analysis≤120字 + goalUpdates + 感情3）の
+            # structured output と、AgentCore Memory から取得する会話履歴（最大5件）を併せて
+            # 生成するため、1024では出力途中でmax_tokens上限に達しAGENT_ERRORとなる事例があった。
+            # 兄弟エージェント（audio-analysis=2048, feedback-analysis=4096）と整合させ2048に設定。
+            # goalUpdatesがゴール数に比例して伸びるため、ゴール多数のシナリオでも余裕を持たせている。
+            max_tokens=2048,
         )
         # シンプルな1回の呼び出し（ツールなしでstructured outputのみ使用）
         agent = Agent(model=model)

--- a/cdk/lambda/sessionAnalysis/reference_handler.py
+++ b/cdk/lambda/sessionAnalysis/reference_handler.py
@@ -179,11 +179,13 @@ def evaluate_references(
             check_results.append(result)
         except Exception as e:
             logger.error(f"メッセージ評価エラー: {str(e)}")
+            # 評価不能（エラー）は「問題あり」ではなく「対象外」として扱う
+            # （誤検知を避けるため、評価できなかった発言を問題扱いしない）
             check_results.append({
                 "message": user_content,
                 "relatedDocument": "",
                 "reviewComment": f"評価中にエラーが発生: {str(e)}",
-                "related": False
+                "evaluation": "not_applicable"
             })
     
     return {
@@ -191,7 +193,12 @@ def evaluate_references(
         "summary": {
             "totalMessages": len(user_messages),
             "checkedMessages": len(check_results),
-            "relatedCount": sum(1 for r in check_results if r.get("related", False))
+            # 資料に基づいた適切な発言数
+            "appropriateCount": sum(1 for r in check_results if r.get("evaluation") == "appropriate"),
+            # 評価対象外の発言数（挨拶・一般的な進行など、資料参照が不要な発言）
+            "notApplicableCount": sum(1 for r in check_results if r.get("evaluation") == "not_applicable"),
+            # 資料と矛盾する/誤った情報を含む発言数（問題ありの件数）
+            "issueCount": sum(1 for r in check_results if r.get("evaluation") == "issue")
         }
     }
 
@@ -294,11 +301,13 @@ def check_single_message(
             "knowledge_base_id": KNOWLEDGE_BASE_ID,
             "user_message": user_message[:100]
         })
+        # 関連資料が見つからない発言は「問題あり」ではなく「対象外」として扱う
+        # （挨拶や一般的な進行など、そもそも資料参照が不要な発言を問題扱いしないため）
         return {
             "message": user_message,
             "relatedDocument": "",
-            "reviewComment": "関連する参照資料が見つかりませんでした" if language == "ja" else "No related reference documents found",
-            "related": False
+            "reviewComment": "この発言に関連する参照資料はありませんでした（評価対象外）" if language == "ja" else "No reference document is related to this statement (not applicable)",
+            "evaluation": "not_applicable"
         }
     
     # 関連ドキュメントの内容を結合
@@ -327,7 +336,7 @@ def check_single_message(
         "message": user_message,
         "relatedDocument": related_document[:500],  # 長すぎる場合は切り詰め
         "reviewComment": evaluation.get("comment", ""),
-        "related": evaluation.get("related", False)
+        "evaluation": evaluation.get("evaluation", "not_applicable")
     }
 
 
@@ -337,11 +346,33 @@ def evaluate_relevance(
     related_document: str,
     language: str
 ) -> Dict[str, Any]:
-    """Strands Agentsで関連性を評価"""
+    """
+    Strands Agentsで発言を3分類で評価する
+
+    評価区分:
+      - "appropriate"     : 発言が参照資料の内容に沿っており、正確な情報提供ができている
+      - "issue"           : 発言が参照資料の内容と矛盾している、または誤った情報を含んでいる
+      - "not_applicable"  : 挨拶・一般的な進行・意思表示など、参照資料の正誤を問えない発言
+
+    重要: 参照資料に記載がないだけの一般的な発言は "issue" ではなく "not_applicable" とする。
+    "issue" は資料と明確に矛盾する、または事実誤認がある場合に限定する。
+    """
     
     if language == "en":
-        system_prompt = "You are an expert at evaluating whether statements are based on reference documents. Always respond in valid JSON format."
-        prompt = f"""Evaluate whether the user's statement is based on the reference document.
+        system_prompt = (
+            "You are an expert at evaluating whether a sales representative's statement "
+            "is consistent with reference documents. Always respond in valid JSON format. "
+            "Only flag a statement as an issue when it clearly contradicts the reference "
+            "document or contains factual errors. Greetings, general remarks, or statements "
+            "of intent that the document neither supports nor contradicts must be classified "
+            "as 'not_applicable', NOT as an issue."
+        )
+        prompt = f"""Classify the user's statement into exactly one of three categories based on the reference document.
+
+Categories:
+- "appropriate": The statement is consistent with and supported by the reference document (accurate information).
+- "issue": The statement clearly contradicts the reference document or contains factual errors.
+- "not_applicable": The statement is a greeting, general remark, or statement of intent that the document neither supports nor contradicts. The absence of related information in the document alone means "not_applicable", NOT "issue".
 
 User's statement: "{user_message}"
 
@@ -352,10 +383,21 @@ Conversation context:
 {context}
 
 Respond in JSON format:
-{{"related": true/false, "comment": "Brief evaluation comment"}}"""
+{{"evaluation": "appropriate" | "issue" | "not_applicable", "comment": "Brief evaluation comment explaining the classification"}}"""
     else:
-        system_prompt = "あなたは発言が参照資料に基づいているかを評価する専門家です。必ず有効なJSON形式で回答してください。"
-        prompt = f"""ユーザーの発言が参照資料に基づいているか評価してください。
+        system_prompt = (
+            "あなたは営業担当者の発言が参照資料の内容と整合しているかを評価する専門家です。"
+            "必ず有効なJSON形式で回答してください。"
+            "発言が参照資料と明確に矛盾している、または事実誤認を含む場合のみ「問題あり(issue)」と判定してください。"
+            "挨拶・一般的な進行・意思表示など、資料が肯定も否定もしない発言は「問題あり」ではなく"
+            "「対象外(not_applicable)」に分類してください。"
+        )
+        prompt = f"""ユーザーの発言を、参照資料の内容に基づき次の3区分のいずれか1つに分類してください。
+
+区分:
+- "appropriate"（適切）: 発言が参照資料の内容に沿っており、正確な情報提供ができている。
+- "issue"（問題あり）: 発言が参照資料の内容と明確に矛盾している、または誤った情報を含んでいる。
+- "not_applicable"（対象外）: 挨拶・一般的な進行・意思表示など、参照資料の正誤を問えない発言。資料に関連記載が「ないだけ」の場合は "issue" ではなく "not_applicable" とすること。
 
 ユーザーの発言: "{user_message}"
 
@@ -366,7 +408,7 @@ Respond in JSON format:
 {context}
 
 JSON形式で回答してください:
-{{"related": true/false, "comment": "簡潔な評価コメント"}}"""
+{{"evaluation": "appropriate" | "issue" | "not_applicable", "comment": "分類理由を含む簡潔な評価コメント"}}"""
     
     try:
         logger.info("関連性評価開始", extra={
@@ -398,8 +440,18 @@ JSON形式で回答してください:
         json_end = response_text.rfind("}") + 1
         if json_start >= 0 and json_end > json_start:
             parsed_result = json.loads(response_text[json_start:json_end])
-            logger.info("関連性評価完了", extra={"related": parsed_result.get("related")})
-            return parsed_result
+
+            # evaluationの値を検証（想定外の値は対象外に丸める）
+            evaluation_value = parsed_result.get("evaluation")
+            if evaluation_value not in ("appropriate", "issue", "not_applicable"):
+                logger.warning("想定外のevaluation値", extra={"evaluation": evaluation_value})
+                evaluation_value = "not_applicable"
+
+            logger.info("関連性評価完了", extra={"evaluation": evaluation_value})
+            return {
+                "evaluation": evaluation_value,
+                "comment": parsed_result.get("comment", "")
+            }
         
         logger.warning("JSON解析失敗: JSONが見つかりません", extra={"response": response_text[:200]})
         
@@ -415,7 +467,8 @@ JSON形式で回答してください:
             "model_id": BEDROCK_MODEL_ID
         })
     
+    # 評価できなかった場合は「問題あり」ではなく「対象外」として扱う（誤検知防止）
     return {
-        "related": False,
+        "evaluation": "not_applicable",
         "comment": "評価中にエラーが発生しました" if language == "ja" else "Error during evaluation"
     }

--- a/cdk/lambda/videos/index.py
+++ b/cdk/lambda/videos/index.py
@@ -2,8 +2,14 @@
 動画管理Lambda関数
 
 このモジュールは、録画動画のアップロード処理を行うLambda関数を実装します。
+録画動画はファイルサイズに関わらずマルチパートアップロードで送信するため、
+20分超の長時間セッション（動画+音声で200MBを超える）でも
+S3の EntityTooLarge エラーが発生しない。
+
 主な機能は以下の通りです：
-- 録画動画アップロード用の署名付きURL生成 (/videos/upload-url)
+- マルチパートアップロード開始 (/videos/multipart/create)
+- マルチパートアップロード完了 (/videos/multipart/complete)
+- マルチパートアップロード中断 (/videos/multipart/abort)
 
 注意: 動画分析はStep Functionsで実行されるため、このLambdaでは行いません。
 """
@@ -21,8 +27,13 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # 環境変数
 VIDEO_BUCKET = os.environ.get('VIDEO_BUCKET', '')
-MAX_VIDEO_SIZE_MB = int(os.environ.get('MAX_VIDEO_SIZE_MB', '100'))  # デフォルト最大100MB
-DEFAULT_PRESIGNED_URL_EXPIRY = int(os.environ.get('DEFAULT_PRESIGNED_URL_EXPIRY', '600'))  # デフォルト10分
+# マルチパートアップロード用の署名付きURL有効期限（長時間アップロードに備えてデフォルト1時間）
+MULTIPART_PRESIGNED_URL_EXPIRY = int(os.environ.get('MULTIPART_PRESIGNED_URL_EXPIRY', '3600'))
+# マルチパートアップロードの最大パート数（S3の上限は10,000）
+# 録画は1.5Mbps映像+音声≈1.6Mbps。10MB/パート換算で60分≈68パート、2時間≈150パート程度のため、
+# 余裕を持たせた500（10MB×500=5GB相当）をデフォルトとし、過大なpartCount要求による
+# 署名付きURLの大量同期生成（Lambdaのブロッキング/DoS）を防ぐ。
+MAX_MULTIPART_PARTS = int(os.environ.get('MAX_MULTIPART_PARTS', '500'))
 
 # CORS設定
 cors_config = CORSConfig(
@@ -60,81 +71,247 @@ class BadRequestError(Exception):
 class InternalServerError(Exception):
     pass
 
-# S3アップロード用の署名付きURL生成
-@app.get("/videos/upload-url")
-def generate_upload_url():
+# マルチパートアップロード開始
+@app.post("/videos/multipart/create")
+def create_multipart_upload():
     """
-    動画アップロード用の署名付きURLを生成するエンドポイント
-    
-    クエリパラメータ:
+    マルチパートアップロードを開始し、各パートの署名付きURLを生成するエンドポイント
+
+    長時間セッション（20分超など）の大容量動画ファイルに対応するため、
+    ファイルを複数パートに分割してアップロードする。
+
+    リクエストボディ:
     - sessionId: セッションID
     - contentType: 動画のMIMEタイプ（video/mp4のみサポート）
     - fileName: ファイル名（オプション）
-    
+    - partCount: 分割するパート数（1〜MAX_MULTIPART_PARTS）
+
     レスポンス:
-    - uploadUrl: アップロード用の署名付きURL
+    - uploadId: マルチパートアップロードID
     - videoKey: S3バケット内のオブジェクトキー
+    - partUrls: 各パートの署名付きURLリスト [{ partNumber, url }]
+    - expiresIn: 署名付きURLの有効期限（秒）
     """
     try:
-        # リクエストパラメータの取得
-        session_id = app.current_event.get_query_string_value(name="sessionId", default_value=None)
-        content_type = app.current_event.get_query_string_value(name="contentType", default_value=None)
-        file_name = app.current_event.get_query_string_value(name="fileName", default_value="recording.mp4")
-        
+        body = app.current_event.json_body or {}
+
+        session_id = body.get("sessionId")
+        content_type = body.get("contentType")
+        file_name = body.get("fileName", "recording.mp4")
+        part_count = body.get("partCount")
+
+        # 入力検証
         if not session_id:
             raise BadRequestError("sessionId is required")
-        
+
         if not content_type:
             raise BadRequestError("contentType is required")
-        
-        if content_type != 'video/mp4':
+
+        if content_type != "video/mp4":
             raise BadRequestError("Only video/mp4 format is supported")
-        
-        # S3オブジェクトキーの生成
-        timestamp = int(time.time())
-        video_key = f"videos/{session_id}/{timestamp}_{file_name}"
-        
-        # S3署名付きPOSTフォーム作成（CORS回避のため）
+
+        if not isinstance(part_count, int) or part_count < 1 or part_count > MAX_MULTIPART_PARTS:
+            raise BadRequestError(
+                f"partCount must be an integer between 1 and {MAX_MULTIPART_PARTS}"
+            )
+
         if not VIDEO_BUCKET:
             raise InternalServerError("VIDEO_BUCKET environment variable is not set")
-        
-        logger.info(f"署名付きURL生成開始（動画用）: bucket={VIDEO_BUCKET}, key={video_key}, contentType={content_type}, region={os.environ.get('AWS_REGION')}")
-        
-        # generate_presigned_postを使用してCORSプリフライトリクエストを回避
-        post_data = s3.generate_presigned_post(
+
+        # S3オブジェクトキーの生成（既存のPOST方式と同一の命名規則）
+        timestamp = int(time.time())
+        video_key = f"videos/{session_id}/{timestamp}_{file_name}"
+
+        logger.info(
+            f"マルチパートアップロード開始: bucket={VIDEO_BUCKET}, key={video_key}, "
+            f"partCount={part_count}, contentType={content_type}"
+        )
+
+        # マルチパートアップロードを開始
+        create_response = s3.create_multipart_upload(
             Bucket=VIDEO_BUCKET,
             Key=video_key,
-            Fields={'Content-Type': content_type},
-            Conditions=[
-                ['content-length-range', 1, MAX_VIDEO_SIZE_MB * 1024 * 1024],  # 100MB制限
-                {'Content-Type': content_type}
-            ],
-            ExpiresIn=DEFAULT_PRESIGNED_URL_EXPIRY
+            ContentType=content_type,
         )
-        
-        logger.info(f"署名付きPOST URL生成成功（動画用）: bucket={VIDEO_BUCKET}, key={video_key}")
-        logger.info(f"生成されたURL（動画用）: {post_data['url']}")
-        logger.info(f"フォームデータのフィールド数（動画用）: {len(post_data['fields'])}")
-        logger.info(f"フォームデータの内容（動画用）: {json.dumps(post_data['fields'], default=str)}")
-        
+        upload_id = create_response["UploadId"]
+
+        # 各パートのアップロード用署名付きURLを生成
+        part_urls = []
+        for part_number in range(1, part_count + 1):
+            url = s3.generate_presigned_url(
+                "upload_part",
+                Params={
+                    "Bucket": VIDEO_BUCKET,
+                    "Key": video_key,
+                    "UploadId": upload_id,
+                    "PartNumber": part_number,
+                },
+                ExpiresIn=MULTIPART_PRESIGNED_URL_EXPIRY,
+            )
+            part_urls.append({"partNumber": part_number, "url": url})
+
+        logger.info(
+            f"マルチパートアップロードURL生成成功: key={video_key}, "
+            f"uploadId={upload_id}, parts={len(part_urls)}"
+        )
+
         return {
-            "uploadUrl": post_data["url"],
-            "formData": post_data["fields"],
+            "uploadId": upload_id,
             "videoKey": video_key,
-            "expiresIn": DEFAULT_PRESIGNED_URL_EXPIRY
+            "partUrls": part_urls,
+            "expiresIn": MULTIPART_PRESIGNED_URL_EXPIRY,
         }
-        
+
     except BadRequestError as e:
-        logger.warn(f"Bad request: {str(e)}")
+        logger.warning(f"Bad request: {str(e)}")
         return {"error": str(e)}, 400
-    
+
     except InternalServerError as e:
         logger.error(f"Internal server error: {str(e)}")
         return {"error": "Internal server error"}, 500
-    
+
     except Exception as e:
-        logger.error(f"Error generating presigned URL: {str(e)}")
-        return {"error": "Failed to generate upload URL"}, 500
+        logger.error(f"Error creating multipart upload: {str(e)}")
+        return {"error": "Failed to create multipart upload"}, 500
+
+
+# マルチパートアップロード完了
+@app.post("/videos/multipart/complete")
+def complete_multipart_upload():
+    """
+    マルチパートアップロードを完了するエンドポイント
+
+    全パートのアップロード完了後、S3に対してパートの結合を指示する。
+
+    リクエストボディ:
+    - videoKey: S3バケット内のオブジェクトキー
+    - uploadId: マルチパートアップロードID
+    - parts: 各パートの情報リスト [{ partNumber, eTag }]
+
+    レスポンス:
+    - videoKey: S3バケット内のオブジェクトキー
+    - location: アップロード完了したオブジェクトのURL
+    """
+    try:
+        body = app.current_event.json_body or {}
+
+        video_key = body.get("videoKey")
+        upload_id = body.get("uploadId")
+        parts = body.get("parts")
+
+        # 入力検証
+        if not video_key:
+            raise BadRequestError("videoKey is required")
+
+        if not upload_id:
+            raise BadRequestError("uploadId is required")
+
+        if not isinstance(parts, list) or len(parts) == 0:
+            raise BadRequestError("parts must be a non-empty list")
+
+        if not VIDEO_BUCKET:
+            raise InternalServerError("VIDEO_BUCKET environment variable is not set")
+
+        # S3が要求する形式に変換（PartNumber昇順でソート）
+        multipart_parts = []
+        for part in parts:
+            part_number = part.get("partNumber")
+            etag = part.get("eTag")
+            if not isinstance(part_number, int) or not etag:
+                raise BadRequestError("Each part must have partNumber (int) and eTag")
+            multipart_parts.append({"PartNumber": part_number, "ETag": etag})
+
+        multipart_parts.sort(key=lambda p: p["PartNumber"])
+
+        logger.info(
+            f"マルチパートアップロード完了処理: key={video_key}, "
+            f"uploadId={upload_id}, parts={len(multipart_parts)}"
+        )
+
+        complete_response = s3.complete_multipart_upload(
+            Bucket=VIDEO_BUCKET,
+            Key=video_key,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": multipart_parts},
+        )
+
+        logger.info(f"マルチパートアップロード完了成功: key={video_key}")
+
+        return {
+            "videoKey": video_key,
+            "location": complete_response.get("Location", ""),
+        }
+
+    except BadRequestError as e:
+        logger.warning(f"Bad request: {str(e)}")
+        return {"error": str(e)}, 400
+
+    except InternalServerError as e:
+        logger.error(f"Internal server error: {str(e)}")
+        return {"error": "Internal server error"}, 500
+
+    except Exception as e:
+        logger.error(f"Error completing multipart upload: {str(e)}")
+        return {"error": "Failed to complete multipart upload"}, 500
+
+
+# マルチパートアップロード中断
+@app.post("/videos/multipart/abort")
+def abort_multipart_upload():
+    """
+    マルチパートアップロードを中断するエンドポイント
+
+    アップロード失敗時に呼び出し、アップロード済みパートを破棄して
+    不要なストレージ課金を防ぐ。
+
+    リクエストボディ:
+    - videoKey: S3バケット内のオブジェクトキー
+    - uploadId: マルチパートアップロードID
+
+    レスポンス:
+    - aborted: 中断成功フラグ
+    """
+    try:
+        body = app.current_event.json_body or {}
+
+        video_key = body.get("videoKey")
+        upload_id = body.get("uploadId")
+
+        # 入力検証
+        if not video_key:
+            raise BadRequestError("videoKey is required")
+
+        if not upload_id:
+            raise BadRequestError("uploadId is required")
+
+        if not VIDEO_BUCKET:
+            raise InternalServerError("VIDEO_BUCKET environment variable is not set")
+
+        logger.info(
+            f"マルチパートアップロード中断: key={video_key}, uploadId={upload_id}"
+        )
+
+        s3.abort_multipart_upload(
+            Bucket=VIDEO_BUCKET,
+            Key=video_key,
+            UploadId=upload_id,
+        )
+
+        logger.info(f"マルチパートアップロード中断成功: key={video_key}")
+
+        return {"aborted": True}
+
+    except BadRequestError as e:
+        logger.warning(f"Bad request: {str(e)}")
+        return {"error": str(e)}, 400
+
+    except InternalServerError as e:
+        logger.error(f"Internal server error: {str(e)}")
+        return {"error": "Internal server error"}, 500
+
+    except Exception as e:
+        logger.error(f"Error aborting multipart upload: {str(e)}")
+        return {"error": "Failed to abort multipart upload"}, 500
 
 # Lambda handler
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)

--- a/cdk/lib/constructs/api/api-gateway.ts
+++ b/cdk/lib/constructs/api/api-gateway.ts
@@ -153,10 +153,37 @@ export class ApiGatewayConstruct extends Construct {
     // Videos API endpoints (動画管理・分析API)
     const videosResource = this.api.root.addResource('videos');
 
-    // GET /videos/upload-url - 動画アップロード用署名付きURL生成エンドポイント
-    const uploadUrlResource = videosResource.addResource('upload-url');
-    uploadUrlResource.addMethod(
-      'GET',
+    // マルチパートアップロード用エンドポイント群
+    // 録画動画はファイルサイズに関わらずマルチパート方式でアップロードするため、
+    // 長時間セッションの大容量動画（200MB超）にも対応する
+    const multipartResource = videosResource.addResource('multipart');
+
+    // POST /videos/multipart/create - マルチパートアップロード開始 + パートURL生成
+    const multipartCreateResource = multipartResource.addResource('create');
+    multipartCreateResource.addMethod(
+      'POST',
+      new apigateway.LambdaIntegration(props.videosFunction),
+      {
+        authorizationType: apigateway.AuthorizationType.COGNITO,
+        authorizer: auth
+      }
+    );
+
+    // POST /videos/multipart/complete - マルチパートアップロード完了
+    const multipartCompleteResource = multipartResource.addResource('complete');
+    multipartCompleteResource.addMethod(
+      'POST',
+      new apigateway.LambdaIntegration(props.videosFunction),
+      {
+        authorizationType: apigateway.AuthorizationType.COGNITO,
+        authorizer: auth
+      }
+    );
+
+    // POST /videos/multipart/abort - マルチパートアップロード中断
+    const multipartAbortResource = multipartResource.addResource('abort');
+    multipartAbortResource.addMethod(
+      'POST',
       new apigateway.LambdaIntegration(props.videosFunction),
       {
         authorizationType: apigateway.AuthorizationType.COGNITO,

--- a/cdk/lib/constructs/api/videos-lambda.ts
+++ b/cdk/lib/constructs/api/videos-lambda.ts
@@ -63,8 +63,12 @@ export class VideosLambdaConstruct extends Construct {
       environment: {
         SESSION_FEEDBACK_TABLE: props.feedbackTableName,
         VIDEO_BUCKET: props.videoBucket.bucketName,
-        MAX_VIDEO_SIZE_MB: '200',  // 200MB
-        DEFAULT_PRESIGNED_URL_EXPIRY: '600', // 10分
+        MULTIPART_PRESIGNED_URL_EXPIRY: '3600', // 1時間（長時間セッションのマルチパートアップロード用）
+        // マルチパートの最大パート数。録画は1.5Mbps映像+音声≈1.6Mbpsで、
+        // 10MB/パート換算だと60分≈68パート・2時間≈150パート程度。
+        // 余裕を見て500（=10MB×500=5GB相当）に制限し、過大なpartCount要求による
+        // 署名付きURL大量生成（Lambdaのブロッキング/DoS）を防ぐ。
+        MAX_MULTIPART_PARTS: '500',
         VIDEO_ANALYSIS_MODEL_ID: props.videoAnalysisModelId || 'global.amazon.nova-2-lite-v1:0',
         POWERTOOLS_LOG_LEVEL: "DEBUG",
         AWS_MAX_ATTEMPTS: "10",
@@ -72,6 +76,9 @@ export class VideosLambdaConstruct extends Construct {
     });
 
     // S3バケットへのアクセス許可
+    // grantReadWriteには PutObject / GetObject / DeleteObject / AbortMultipartUpload /
+    // ListBucketMultipartUploads / ListMultipartUploadParts が含まれ、
+    // マルチパートアップロードに必要な権限を満たす
     props.videoBucket.grantReadWrite(this.function);
 
     // DynamoDBテーブルへのアクセス許可

--- a/cdk/lib/constructs/storage/video-storage.ts
+++ b/cdk/lib/constructs/storage/video-storage.ts
@@ -37,6 +37,11 @@ export class VideoStorageConstruct extends Construct {
           // 未使用の動画ファイルは14日後に削除（録画データは容量が大きいため短めの期間設定）
           expiration: cdk.Duration.days(14),
           prefix: 'videos/',
+        },
+        {
+          // 中断・失敗したマルチパートアップロードの残骸を1日後に自動削除し、
+          // 不要なストレージ課金を防ぐ
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
         }
       ],
       // サーバーサイド暗号化を有効化

--- a/frontend/src/__tests__/components/MessageAccordion.test.tsx
+++ b/frontend/src/__tests__/components/MessageAccordion.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MessageAccordion from "../../components/referenceCheck/MessageAccordion";
+import type { ReferenceCheckEvaluation } from "../../types/api";
+
+// i18nのモック（デフォルト値を返す）
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, _defaultValue?: unknown, options?: unknown) => {
+      const translations: { [key: string]: string } = {
+        "referenceCheck.status.success": "適切",
+        "referenceCheck.status.issue": "問題あり",
+        "referenceCheck.status.notApplicable": "対象外",
+        "referenceCheck.userMessage": "ユーザーの発言",
+        "referenceCheck.relatedDocument": "関連ドキュメント",
+        "referenceCheck.reviewComment": "レビューコメント",
+      };
+      if (key === "referenceCheck.messageNumber") {
+        const opts = options as { number: number } | undefined;
+        return `メッセージ ${opts?.number ?? ""}`;
+      }
+      return translations[key] || key;
+    },
+  }),
+}));
+
+/**
+ * MessageAccordionコンポーネントのテスト
+ *
+ * 3分類評価（appropriate / not_applicable / issue）に応じた
+ * ステータスラベルが正しく表示されることを検証する。
+ */
+describe("MessageAccordion", () => {
+  const renderAccordion = (evaluation: ReferenceCheckEvaluation) =>
+    render(
+      <MessageAccordion
+        message={{
+          message: "テストメッセージ",
+          evaluation,
+          relatedDocument: "テスト資料",
+          reviewComment: "テストコメント",
+        }}
+        index={0}
+      />,
+    );
+
+  test("appropriateの場合「適切」ラベルが表示される", () => {
+    renderAccordion("appropriate");
+    expect(screen.getByText("適切")).toBeInTheDocument();
+  });
+
+  test("issueの場合「問題あり」ラベルが表示される", () => {
+    renderAccordion("issue");
+    expect(screen.getByText("問題あり")).toBeInTheDocument();
+  });
+
+  test("not_applicableの場合「対象外」ラベルが表示される", () => {
+    renderAccordion("not_applicable");
+    expect(screen.getByText("対象外")).toBeInTheDocument();
+  });
+
+  test("メッセージ本文・関連ドキュメント・レビューコメントが表示される", () => {
+    renderAccordion("issue");
+    expect(screen.getByText("テストメッセージ")).toBeInTheDocument();
+    expect(screen.getByText("テスト資料")).toBeInTheDocument();
+    expect(screen.getByText("テストコメント")).toBeInTheDocument();
+  });
+
+  test("メッセージ番号が表示される", () => {
+    renderAccordion("appropriate");
+    expect(
+      screen.getByText((content) => content.startsWith("メッセージ")),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/ReferenceCheckResults.test.tsx
+++ b/frontend/src/__tests__/components/ReferenceCheckResults.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ReferenceCheckResults from "../../components/referenceCheck/ReferenceCheckResults";
+import type { ReferenceCheckResult } from "../../types/api";
+
+// i18nのモック（デフォルト値を返す）
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, _defaultValue?: unknown, options?: unknown) => {
+      const translations: { [key: string]: string } = {
+        "referenceCheck.noIssuesTitle": "問題なし",
+        "referenceCheck.noIssues": "整合性に問題は見つかりませんでした。",
+        "referenceCheck.issuesFoundTitle": "問題が発見されました",
+        "referenceCheck.issuesFoundDescription": "問題が見つかりました。",
+        "referenceCheck.problemMessages": "問題のあるメッセージ",
+        "referenceCheck.allMessages": "全メッセージの詳細",
+        "referenceCheck.status.success": "適切",
+        "referenceCheck.status.issue": "問題あり",
+        "referenceCheck.status.notApplicable": "対象外",
+        "referenceCheck.userMessage": "ユーザーの発言",
+        "referenceCheck.relatedDocument": "関連ドキュメント",
+        "referenceCheck.reviewComment": "レビューコメント",
+        "referenceCheck.explanationTitle": "リファレンスチェックについて",
+        "referenceCheck.explanation1": "説明1",
+        "referenceCheck.explanation2": "説明2",
+      };
+      if (key === "referenceCheck.messageNumber") {
+        const opts = options as { number: number } | undefined;
+        return `メッセージ ${opts?.number ?? ""}`;
+      }
+      return translations[key] || key;
+    },
+  }),
+}));
+
+/**
+ * ReferenceCheckResultsコンポーネントのテスト
+ *
+ * issuesCountに応じた表示分岐と、問題リストに「issue」のみが
+ * 抽出されることを検証する。
+ */
+describe("ReferenceCheckResults", () => {
+  const createData = (
+    evaluations: ReferenceCheckResult["messages"][number]["evaluation"][],
+  ): ReferenceCheckResult => ({
+    messages: evaluations.map((evaluation, index) => ({
+      message: `発言${index + 1}`,
+      relatedDocument: "",
+      reviewComment: "",
+      evaluation,
+    })),
+    summary: {
+      totalMessages: evaluations.length,
+      checkedMessages: evaluations.length,
+    },
+  });
+
+  test("issuesCountが0の場合「問題なし」が表示される", () => {
+    const data = createData(["appropriate", "not_applicable"]);
+    render(<ReferenceCheckResults data={data} issuesCount={0} />);
+
+    expect(screen.getByText("問題なし")).toBeInTheDocument();
+    expect(screen.queryByText("問題が発見されました")).not.toBeInTheDocument();
+  });
+
+  test("対象外のみの会話では「問題なし」が表示される", () => {
+    // 挨拶や一般的な進行など資料参照が不要な発言のみのケース
+    const data = createData(["not_applicable", "not_applicable"]);
+    render(<ReferenceCheckResults data={data} issuesCount={0} />);
+
+    expect(screen.getByText("問題なし")).toBeInTheDocument();
+  });
+
+  test("issuesCountが1以上の場合「問題が発見されました」が表示される", () => {
+    const data = createData(["issue", "appropriate"]);
+    render(<ReferenceCheckResults data={data} issuesCount={1} />);
+
+    // AlertTitle内は件数表示で複数ノードに分割されるため部分一致で確認
+    expect(
+      screen.getByText((content) => content.includes("問題が発見されました")),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("問題なし")).not.toBeInTheDocument();
+  });
+
+  test("問題のあるメッセージセクションにはissueのみが抽出される", () => {
+    const data = createData(["issue", "appropriate", "not_applicable"]);
+    render(<ReferenceCheckResults data={data} issuesCount={1} />);
+
+    // 「問題のあるメッセージ」見出しが表示される
+    expect(screen.getByText("問題のあるメッセージ")).toBeInTheDocument();
+
+    // 問題ありセクション + 全メッセージ詳細で「問題あり」ラベルが表示される
+    // issueは1件なので、問題セクションに1つ、全メッセージに1つ = 2箇所
+    expect(screen.getAllByText("問題あり").length).toBe(2);
+  });
+
+  test("全メッセージ詳細セクションには全件数が表示される", () => {
+    const data = createData(["issue", "appropriate", "not_applicable"]);
+    render(<ReferenceCheckResults data={data} issuesCount={1} />);
+
+    // 全メッセージ詳細セクションが存在する（件数表示で分割されるため部分一致）
+    expect(
+      screen.getByText((content) => content.includes("全メッセージの詳細")),
+    ).toBeInTheDocument();
+    // 対象外ラベルが全メッセージ詳細に表示される
+    expect(screen.getByText("対象外")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/hooks/useReferenceCheck.test.ts
+++ b/frontend/src/__tests__/hooks/useReferenceCheck.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from "@testing-library/react";
+import { useReferenceCheck } from "../../hooks/useReferenceCheck";
+import type { ReferenceCheckResult } from "../../types/api";
+
+/**
+ * useReferenceCheckフックのテスト
+ *
+ * 3分類評価（appropriate / not_applicable / issue）のうち、
+ * 「問題あり (issue)」のみがissuesCountにカウントされることを検証する。
+ */
+describe("useReferenceCheck", () => {
+  /**
+   * テスト用のリファレンスチェック結果を生成するヘルパー
+   */
+  const createResult = (
+    evaluations: ReferenceCheckResult["messages"][number]["evaluation"][],
+  ): ReferenceCheckResult => ({
+    messages: evaluations.map((evaluation, index) => ({
+      message: `メッセージ${index + 1}`,
+      relatedDocument: "",
+      reviewComment: "",
+      evaluation,
+    })),
+    summary: {
+      totalMessages: evaluations.length,
+      checkedMessages: evaluations.length,
+    },
+  });
+
+  test("initialDataがnullの場合、issuesCountは0になる", () => {
+    const { result } = renderHook(() => useReferenceCheck(true, null));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.issuesCount).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAnalyzing).toBe(false);
+    expect(result.current.error).toBe("");
+  });
+
+  test("issueの発言のみがissuesCountにカウントされる", () => {
+    const data = createResult(["issue", "appropriate", "not_applicable"]);
+    const { result } = renderHook(() => useReferenceCheck(true, data));
+
+    expect(result.current.issuesCount).toBe(1);
+  });
+
+  test("not_applicable（対象外）は問題としてカウントされない", () => {
+    // 挨拶や一般的な進行など、資料参照が不要な発言のみのケース
+    const data = createResult(["not_applicable", "not_applicable"]);
+    const { result } = renderHook(() => useReferenceCheck(true, data));
+
+    expect(result.current.issuesCount).toBe(0);
+  });
+
+  test("appropriate（適切）のみの場合、issuesCountは0になる", () => {
+    const data = createResult(["appropriate", "appropriate"]);
+    const { result } = renderHook(() => useReferenceCheck(true, data));
+
+    expect(result.current.issuesCount).toBe(0);
+  });
+
+  test("複数のissueがある場合、その件数がカウントされる", () => {
+    const data = createResult([
+      "issue",
+      "issue",
+      "appropriate",
+      "not_applicable",
+      "issue",
+    ]);
+    const { result } = renderHook(() => useReferenceCheck(true, data));
+
+    expect(result.current.issuesCount).toBe(3);
+  });
+
+  test("isVisibleがfalseの場合、dataはnullになるがissuesCountは計算される", () => {
+    const data = createResult(["issue", "appropriate"]);
+    const { result } = renderHook(() => useReferenceCheck(false, data));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.issuesCount).toBe(1);
+  });
+});

--- a/frontend/src/components/recording/v2/VideoRecorder.tsx
+++ b/frontend/src/components/recording/v2/VideoRecorder.tsx
@@ -3,6 +3,11 @@ import { Box, Alert, Snackbar } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import type { VideoRecorderRef } from "../../../types/components";
 
+// マルチパートアップロードの1パートあたりのサイズ（10MB、S3の最小5MB以上）
+// 録画動画はファイルサイズに関わらずマルチパートアップロードで送信するため、
+// 長時間セッションの大容量動画（200MB超）でもS3のサイズ制限に達しない
+const MULTIPART_PART_SIZE_BYTES = 10 * 1024 * 1024;
+
 interface VideoRecorderProps {
   sessionId: string;
   isActive: boolean; // セッションがアクティブかどうか（録画を行うべきかどうか）
@@ -274,79 +279,125 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
     }
   };
 
-  // リトライ機能付きアップロード
-  const uploadWithRetry = async (uploadInfo: { uploadUrl: string; formData: Record<string, string> }, blob: Blob, videoKey: string, maxRetries = 3) => {
+  // 1パートのアップロード（リトライ機能付き、ETagを返す）
+  const uploadPartWithRetry = async (
+    url: string,
+    partBlob: Blob,
+    partNumber: number,
+    maxRetries = 3,
+  ): Promise<string> => {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        if (import.meta.env.DEV) console.log(`Upload attempt ${attempt}/${maxRetries}`);
-        if (import.meta.env.DEV) console.log("Form data fields:", Object.keys(uploadInfo.formData));
-
-        const formData = new FormData();
-
-        // S3 presigned POSTでは、フィールドの順序が重要
-        // 'key'フィールドを最初に、'file'フィールドを最後に追加する必要がある
-        // また、'Content-Type'フィールドも正しく追加する必要がある
-        const orderedFields = ['key', 'Content-Type', 'x-amz-algorithm', 'x-amz-credential', 'x-amz-date', 'x-amz-security-token', 'policy', 'x-amz-signature'];
-
-        // 順序通りにフィールドを追加
-        orderedFields.forEach(fieldName => {
-          if (uploadInfo.formData[fieldName]) {
-            formData.append(fieldName, uploadInfo.formData[fieldName]);
-            if (import.meta.env.DEV) console.log(`Field added: ${fieldName}`);
-          }
-        });
-
-        // 残りのフィールドを追加（上記以外のフィールドがある場合）
-        Object.entries(uploadInfo.formData).forEach(([key, value]) => {
-          if (!orderedFields.includes(key)) {
-            formData.append(key, value);
-            if (import.meta.env.DEV) console.log(`Additional field: ${key}`);
-          }
-        });
-
-        // fileフィールドは必ず最後に追加（ファイル名も指定）
-        const file = new File([blob], videoKey.split('/').pop() || 'recording.mp4', { type: 'video/mp4' });
-        formData.append("file", file);
-        if (import.meta.env.DEV) console.log(`File added: size=${file.size}, name=${file.name}, type=${file.type}`);
-
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 300000); // 5分タイムアウト
+        const timeoutId = setTimeout(() => controller.abort(), 300000); // 1パートあたり5分タイムアウト
 
-        const response = await fetch(uploadInfo.uploadUrl, {
-          method: "POST",
-          body: formData,
-          signal: controller.signal
+        const response = await fetch(url, {
+          method: "PUT",
+          body: partBlob,
+          signal: controller.signal,
         });
 
         clearTimeout(timeoutId);
 
-        if (response.ok || response.status === 204) {
-          if (import.meta.env.DEV) console.log("S3 upload success:", response.status);
-          localStorage.setItem("lastRecordingKey", videoKey);
-          if (import.meta.env.DEV) console.log("Recording key saved to localStorage:", videoKey);
-
-          // 録画完了イベントを発火
-          const event = new CustomEvent('recordingComplete', {
-            detail: { videoKey, sessionId }
-          });
-          window.dispatchEvent(event);
-          return; // 成功したら終了
-        } else {
-          // エラーレスポンスの詳細を取得
+        if (!response.ok) {
           const errorText = await response.text();
-          console.error(`S3 error response: ${errorText}`);
           throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
         }
-      } catch (error) {
-        console.error(`Upload attempt ${attempt} failed:`, error);
 
-        if (attempt === maxRetries) {
-          throw error; // 最後の試行で失敗したらエラーを投げる
+        // S3はパートアップロードのレスポンスでETagヘッダーを返す
+        // （CORSのexposedHeadersでETagを公開済み）
+        const eTag = response.headers.get("ETag");
+        if (!eTag) {
+          throw new Error(`ETag header not found for part ${partNumber}`);
         }
 
+        if (import.meta.env.DEV) {
+          console.log(`Part ${partNumber} uploaded: eTag=${eTag}`);
+        }
+        return eTag;
+      } catch (error) {
+        console.error(`Part ${partNumber} upload attempt ${attempt} failed:`, error);
+
+        if (attempt === maxRetries) {
+          throw error;
+        }
         // 指数バックオフで待機
         await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
       }
+    }
+    // ここには到達しないが型のために明示
+    throw new Error(`Failed to upload part ${partNumber}`);
+  };
+
+  // localStorageへの書き込み（Safariプライベートモード等で例外が発生しても
+  // アップロード成功処理全体を失敗させないよう、try-catchで保護する）
+  const safeSetLocalStorage = (key: string, value: string) => {
+    try {
+      localStorage.setItem(key, value);
+    } catch (storageError) {
+      console.warn(`localStorageへの保存に失敗しました（key=${key}）:`, storageError);
+    }
+  };
+
+  // マルチパートアップロード（長時間セッションの大容量動画向け）
+  // 成功時はサーバーが採番した動画キー（videos/{sessionId}/...）を返す。
+  // 呼び出し元はこのキーを下流処理（localStorage・録画完了通知）に使い、
+  // フロント・バックエンド間でキーを一本化する。
+  const uploadWithMultipart = async (
+    blob: Blob,
+    sessionId: string,
+    videoKey: string,
+  ): Promise<string> => {
+    const { ApiService } = await import("../../../services/ApiService");
+    const apiService = ApiService.getInstance();
+
+    // パート数を算出（S3の仕様上、最後のパート以外は5MB以上必要）
+    const partCount = Math.ceil(blob.size / MULTIPART_PART_SIZE_BYTES);
+    const fileName = videoKey.split("/").pop() || "recording.mp4";
+
+    if (import.meta.env.DEV) {
+      console.log(
+        `Multipart upload start: size=${Math.round(blob.size / 1024 / 1024 * 100) / 100}MB, parts=${partCount}`,
+      );
+    }
+
+    // マルチパートアップロードを開始し、各パートの署名付きURLを取得
+    const { uploadId, videoKey: serverVideoKey, partUrls } =
+      await apiService.createMultipartUpload(sessionId, "video/mp4", partCount, fileName);
+
+    try {
+      // 各パートを順次アップロードしてETagを収集
+      const uploadedParts: Array<{ partNumber: number; eTag: string }> = [];
+      for (const { partNumber, url } of partUrls) {
+        const start = (partNumber - 1) * MULTIPART_PART_SIZE_BYTES;
+        const end = Math.min(start + MULTIPART_PART_SIZE_BYTES, blob.size);
+        const partBlob = blob.slice(start, end);
+
+        const eTag = await uploadPartWithRetry(url, partBlob, partNumber);
+        uploadedParts.push({ partNumber, eTag });
+      }
+
+      // 全パート完了後、S3にパート結合を指示
+      await apiService.completeMultipartUpload(serverVideoKey, uploadId, uploadedParts);
+
+      if (import.meta.env.DEV) console.log("Multipart upload success:", serverVideoKey);
+
+      // サーバー採番のキーで保存・通知し、フロント/バックエンドのキーを一致させる
+      safeSetLocalStorage("lastRecordingKey", serverVideoKey);
+
+      // 録画完了イベントを発火
+      const event = new CustomEvent("recordingComplete", {
+        detail: { videoKey: serverVideoKey, sessionId },
+      });
+      window.dispatchEvent(event);
+
+      // 呼び出し元がサーバー採番のキーを使えるよう返却する
+      return serverVideoKey;
+    } catch (error) {
+      // 失敗時はマルチパートアップロードを中断してパートの残骸を破棄
+      console.error("Multipart upload failed, aborting:", error);
+      await apiService.abortMultipartUpload(serverVideoKey, uploadId);
+      throw error;
     }
   };
 
@@ -358,27 +409,17 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
         throw new Error(t("recording.sessionIdNotSet"));
       }
 
-      const videoKey = `session_${sessionId}_${new Date().getTime()}.mp4`;
-      if (import.meta.env.DEV) console.log("S3 upload start:", videoKey, "size:", Math.round(blob.size / 1024 / 1024 * 100) / 100, "MB");
+      // ローカルの仮キー。アップロード成功時はサーバー採番のキーで上書きする
+      const localVideoKey = `session_${sessionId}_${new Date().getTime()}.mp4`;
+      if (import.meta.env.DEV) console.log("S3 upload start:", localVideoKey, "size:", Math.round(blob.size / 1024 / 1024 * 100) / 100, "MB");
 
-      // APIサービスを使用して署名付きURLを取得してS3にアップロード
+      // マルチパートアップロードでS3に保存する
+      // ファイルサイズに関わらずマルチパート方式に統一しており、
+      // 長時間セッションの大容量動画（200MB超）でもS3のサイズ制限に達しない
+      // アップロード成功時はサーバー採番のキー（videos/{sessionId}/...）を採用する
+      let resultVideoKey = localVideoKey;
       try {
-        // ApiServiceのインポート
-        const { ApiService } = await import("../../../services/ApiService");
-        const apiService = ApiService.getInstance();
-
-        // 署名付きURLを取得
-        const contentType = "video/mp4";
-        const uploadInfo = await apiService.getVideoUploadUrl(
-          sessionId,
-          contentType,
-          videoKey,
-        );
-        if (import.meta.env.DEV) console.log("Signed URL obtained:", uploadInfo.uploadUrl);
-
-        // BlobをS3にPOSTフォームでアップロード（リトライ機能付き）
-        await uploadWithRetry(uploadInfo, blob, videoKey);
-
+        resultVideoKey = await uploadWithMultipart(blob, sessionId, localVideoKey);
       } catch (uploadError) {
         console.error("S3 upload process error:", uploadError);
         // エラーが発生した場合でも、親コンポーネントにエラー情報を渡す
@@ -388,11 +429,12 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
         // エラーが発生してもvideoKeyは渡して処理を続行
       }
 
-      if (import.meta.env.DEV) console.log("Recording data saved:", videoKey);
+      if (import.meta.env.DEV) console.log("Recording data saved:", resultVideoKey);
 
       // コールバックを呼び出し（エラーが発生してもvideoKeyは渡す）
+      // 成功時はサーバー採番のキー、失敗時はローカル仮キーを渡す
       if (onRecordingComplete) {
-        onRecordingComplete(videoKey);
+        onRecordingComplete(resultVideoKey);
       }
     } catch (err) {
       console.error("Recording data processing failed:", err);

--- a/frontend/src/components/referenceCheck/MessageAccordion.tsx
+++ b/frontend/src/components/referenceCheck/MessageAccordion.tsx
@@ -12,15 +12,17 @@ import {
   ExpandMore as ExpandMoreIcon,
   CheckCircle as CheckCircleIcon,
   Warning as WarningIcon,
+  RemoveCircleOutline as RemoveCircleOutlineIcon,
 } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
+import type { ReferenceCheckEvaluation } from "../../types/api";
 
 /**
  * メッセージの型定義
  */
 interface Message {
   message: string;
-  related: boolean;
+  evaluation: ReferenceCheckEvaluation;
   relatedDocument?: string;
   reviewComment?: string;
 }
@@ -34,27 +36,38 @@ interface MessageAccordionProps {
 }
 
 /**
- * メッセージの状態に応じたプロパティを取得
- * @param message メッセージオブジェクト
+ * メッセージの評価区分に応じたプロパティを取得
+ * @param evaluation 評価区分（3分類）
  * @param t 翻訳関数
  * @returns メッセージプロパティ
  */
 const getMessageProps = (
-  message: { related: boolean },
+  evaluation: ReferenceCheckEvaluation,
   t: (key: string, defaultValue: string) => string,
 ) => {
-  if (message.related) {
-    return {
-      color: "success" as const,
-      icon: <CheckCircleIcon />,
-      label: t("referenceCheck.status.success", "適切"),
-    };
-  } else {
-    return {
-      color: "warning" as const,
-      icon: <WarningIcon />,
-      label: t("referenceCheck.status.issue", "問題あり"),
-    };
+  switch (evaluation) {
+    case "appropriate":
+      return {
+        color: "success" as const,
+        icon: <CheckCircleIcon />,
+        label: t("referenceCheck.status.success", "適切"),
+        commentBgColor: "#e8f5e8",
+      };
+    case "issue":
+      return {
+        color: "warning" as const,
+        icon: <WarningIcon />,
+        label: t("referenceCheck.status.issue", "問題あり"),
+        commentBgColor: "#fff3e0",
+      };
+    case "not_applicable":
+    default:
+      return {
+        color: "default" as const,
+        icon: <RemoveCircleOutlineIcon />,
+        label: t("referenceCheck.status.notApplicable", "対象外"),
+        commentBgColor: "#f5f5f5",
+      };
   }
 };
 
@@ -66,7 +79,7 @@ const MessageAccordion: React.FC<MessageAccordionProps> = ({
   index,
 }) => {
   const { t } = useTranslation();
-  const messageProps = getMessageProps(message, t);
+  const messageProps = getMessageProps(message.evaluation, t);
 
   return (
     <Accordion sx={{ mb: 2 }}>
@@ -112,12 +125,16 @@ const MessageAccordion: React.FC<MessageAccordionProps> = ({
           <Paper
             sx={{
               p: 2,
-              bgcolor: message.related ? "#e8f5e8" : "#fff3e0",
+              bgcolor: messageProps.commentBgColor,
             }}
           >
             <Typography
               variant="subtitle2"
-              color={messageProps.color}
+              color={
+                messageProps.color === "default"
+                  ? "text.secondary"
+                  : messageProps.color
+              }
               gutterBottom
             >
               {t("referenceCheck.reviewComment", "レビューコメント")}

--- a/frontend/src/components/referenceCheck/ReferenceCheckResults.tsx
+++ b/frontend/src/components/referenceCheck/ReferenceCheckResults.tsx
@@ -23,11 +23,13 @@ interface ReferenceCheckResultsProps {
 
 /**
  * 問題があるメッセージかどうかを判定
+ * 「問題あり (issue)」のみを問題として扱う。
+ * 「対象外 (not_applicable)」（挨拶・一般的な進行など）は問題としない。
  * @param msg メッセージオブジェクト
  * @returns 問題がある場合true
  */
-const hasIssue = (msg: { related: boolean }): boolean => {
-  return !msg.related;
+const hasIssue = (msg: { evaluation: string }): boolean => {
+  return msg.evaluation === "issue";
 };
 
 /**

--- a/frontend/src/hooks/useReferenceCheck.ts
+++ b/frontend/src/hooks/useReferenceCheck.ts
@@ -25,9 +25,11 @@ export const useReferenceCheck = (
 ): ReferenceCheckState => {
   /**
    * 問題があるメッセージの数を計算
+   * 「問題あり (issue)」のみをカウントする。
+   * 「対象外 (not_applicable)」（挨拶・一般的な進行など）は問題として扱わない。
    */
   const issuesCount = initialData?.messages
-    ? initialData.messages.filter((msg) => !msg.related).length
+    ? initialData.messages.filter((msg) => msg.evaluation === "issue").length
     : 0;
 
   return {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -959,7 +959,8 @@
     "reviewComment": "Review Comment",
     "status": {
       "success": "Appropriate",
-      "issue": "Issue"
+      "issue": "Issue",
+      "notApplicable": "Not Applicable"
     },
     "severity": {
       "high": "High",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -959,7 +959,8 @@
     "reviewComment": "レビューコメント",
     "status": {
       "success": "適切",
-      "issue": "問題あり"
+      "issue": "問題あり",
+      "notApplicable": "対象外"
     },
     "severity": {
       "high": "高",

--- a/frontend/src/services/AgentCoreService.ts
+++ b/frontend/src/services/AgentCoreService.ts
@@ -26,6 +26,24 @@ const REALTIME_SCORING_RUNTIME_ARN = import.meta.env.VITE_AGENTCORE_REALTIME_SCO
 // AgentCore Data Plane エンドポイント
 const AGENTCORE_ENDPOINT = `https://bedrock-agentcore.${AWS_REGION}.amazonaws.com`;
 
+// アクセストークンの先回り更新しきい値（秒）
+// AgentCoreは「あと1分以内に失効するトークン」を拒否するため、
+// それより十分手前（2分）を切ったら更新し、長いペイロード送信中の失効も吸収する
+const TOKEN_REFRESH_THRESHOLD_SEC = 120;
+
+/**
+ * AgentCore Runtimeが401（認証エラー）を返した場合に投げる専用エラー
+ *
+ * トークン失効・失効間近（"Ineffectual token, will expire within the next minute"）が
+ * 主因のため、呼び出し元はこのエラーを検知してトークンを強制更新し、リトライ判定に使う。
+ */
+class AgentCoreUnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentCoreUnauthorizedError";
+  }
+}
+
 /**
  * AgentCore Runtime サービスクラス
  * 
@@ -49,14 +67,36 @@ export class AgentCoreService {
 
   /**
    * Cognito Access Tokenを取得
-   * 
+   *
    * 注意: AgentCore RuntimeのJWT認証ではAccess Tokenを使用する
    * （ID Tokenではない）
+   *
+   * AgentCoreは「あと1分以内に失効するトークン」を予防的に拒否する
+   * （401 "Ineffectual token, will expire within the next minute"）。
+   * Amplifyの fetchAuthSession はトークンが完全失効するまでキャッシュを返すため、
+   * 残り時間がしきい値（TOKEN_REFRESH_THRESHOLD_SEC）を下回る場合は
+   * forceRefresh で先回り更新し、この隙間による401を防ぐ。
+   *
+   * @param forceRefresh trueの場合、残り時間に関わらずトークンを強制更新する
+   *                     （401リトライ時に使用）
    */
-  private async getAccessToken(): Promise<string> {
+  private async getAccessToken(forceRefresh = false): Promise<string> {
     try {
       await getCurrentUser();
-      const authSession = await fetchAuthSession();
+      let authSession = await fetchAuthSession(
+        forceRefresh ? { forceRefresh: true } : undefined,
+      );
+
+      // 強制更新でない場合は、失効が近ければ先回りで更新する
+      if (!forceRefresh) {
+        const expSec = authSession.tokens?.accessToken?.payload?.exp;
+        if (typeof expSec === "number") {
+          const remainingSec = expSec - Math.floor(Date.now() / 1000);
+          if (remainingSec < TOKEN_REFRESH_THRESHOLD_SEC) {
+            authSession = await fetchAuthSession({ forceRefresh: true });
+          }
+        }
+      }
 
       if (!authSession.tokens?.accessToken) {
         throw new Error("Access Tokenが取得できません");
@@ -81,14 +121,57 @@ export class AgentCoreService {
    * 
    * JWT認証を使用する場合、AWS SDKではなくHTTPS直接リクエストを使用
    * タイムアウト: 120秒（API Gatewayの29秒制限を回避）
+   *
+   * 401（トークン失効・失効間近）の場合は、トークンを強制更新して1回だけリトライする。
+   * AgentCoreは残り1分以内のトークンを拒否するため、先回り更新（getAccessToken）を
+   * すり抜けたケースの保険となる。
    */
   private async invokeAgentCoreRuntime<T>(
     runtimeArn: string,
     sessionId: string,
     payload: Record<string, unknown>
   ): Promise<T> {
+    // 1回目は通常取得（必要なら内部で先回り更新）
     const accessToken = await this.getAccessToken();
 
+    try {
+      return await this.sendAgentCoreRequest<T>(
+        runtimeArn,
+        sessionId,
+        payload,
+        accessToken,
+      );
+    } catch (error) {
+      // 401（認証エラー）の場合のみ、トークンを強制更新して1回リトライ
+      if (error instanceof AgentCoreUnauthorizedError) {
+        console.warn(
+          "AgentCore Runtime 401（トークン失効間近の可能性）。トークンを強制更新して再試行します。",
+        );
+        const refreshedToken = await this.getAccessToken(true);
+        return await this.sendAgentCoreRequest<T>(
+          runtimeArn,
+          sessionId,
+          payload,
+          refreshedToken,
+        );
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * AgentCore Runtimeへ実際のHTTPSリクエストを送信する
+   *
+   * invokeAgentCoreRuntimeのリトライ機構から、トークンを差し替えて再利用できるよう
+   * 単一リクエストの送信処理を切り出したもの。
+   * 401を受け取った場合は AgentCoreUnauthorizedError を投げ、呼び出し元でリトライ判定する。
+   */
+  private async sendAgentCoreRequest<T>(
+    runtimeArn: string,
+    sessionId: string,
+    payload: Record<string, unknown>,
+    accessToken: string,
+  ): Promise<T> {
     // ARNをURLエンコード
     const encodedArn = encodeURIComponent(runtimeArn);
     // エンドポイント形式: /runtimes/{encodedArn}/invocations
@@ -115,6 +198,10 @@ export class AgentCoreService {
       if (!response.ok) {
         const errorText = await response.text();
         console.error(`AgentCore Runtime エラー: ${response.status}`, errorText);
+        // 401はトークン失効系のため、呼び出し元でのリトライ対象として専用エラーを投げる
+        if (response.status === 401) {
+          throw new AgentCoreUnauthorizedError(errorText);
+        }
         throw new Error(`AgentCore Runtime呼び出しエラー: ${response.status} - ${errorText}`);
       }
 

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -1324,50 +1324,128 @@ export class ApiService {
   }
 
   /**
-   * 動画アップロード用の署名付きURLを取得する
+   * マルチパートアップロードを開始し、各パートの署名付きURLを取得する
+   *
+   * セッション録画の動画ファイルは、長時間セッション（20分超など）でも
+   * S3のサイズ制限に達しないよう、ファイルサイズに関わらずマルチパート方式で
+   * アップロードする。
+   *
    * @param sessionId セッションID
-   * @param contentType 動画のコンテントタイプ
+   * @param contentType 動画のコンテントタイプ（video/mp4）
+   * @param partCount 分割するパート数
    * @param fileName ファイル名（オプション）
-   * @returns 署名付きURLと動画キー
+   * @returns マルチパートアップロードID、動画キー、各パートの署名付きURL
    */
-  public async getVideoUploadUrl(
+  public async createMultipartUpload(
     sessionId: string,
     contentType: string,
+    partCount: number,
     fileName?: string,
   ): Promise<{
-    uploadUrl: string;
-    formData: Record<string, string>;
+    uploadId: string;
     videoKey: string;
+    partUrls: Array<{ partNumber: number; url: string }>;
     expiresIn: number;
   }> {
     try {
-      // クエリパラメータの作成
-      const queryParams: Record<string, string | number> = {
-        sessionId: sessionId,
-        contentType: contentType,
-      };
-
-      if (fileName !== undefined) {
-        queryParams.fileName = fileName;
-      }
-
-      // API呼び出し
-      return await this.apiGet<{
-        uploadUrl: string;
-        formData: Record<string, string>;
-        videoKey: string;
-        expiresIn: number;
-      }>("/videos/upload-url", queryParams);
+      return await this.apiPost<
+        {
+          uploadId: string;
+          videoKey: string;
+          partUrls: Array<{ partNumber: number; url: string }>;
+          expiresIn: number;
+        },
+        {
+          sessionId: string;
+          contentType: string;
+          partCount: number;
+          fileName?: string;
+        }
+      >("/videos/multipart/create", {
+        sessionId,
+        contentType,
+        partCount,
+        ...(fileName !== undefined ? { fileName } : {}),
+      });
     } catch (error) {
-      console.error("動画アップロードURL取得に失敗しました:", error);
+      console.error("マルチパートアップロード開始に失敗しました:", error);
 
       if (error instanceof Error) {
         throw new Error(
-          `動画アップロードURL取得に失敗しました: ${error.message}`,
+          `マルチパートアップロード開始に失敗しました: ${error.message}`,
         );
       } else {
-        throw new Error("動画アップロードURL取得に失敗しました");
+        throw new Error("マルチパートアップロード開始に失敗しました");
       }
+    }
+  }
+
+  /**
+   * マルチパートアップロードを完了する
+   *
+   * 全パートのアップロード完了後、S3に対してパートの結合を指示する。
+   *
+   * @param videoKey 動画キー
+   * @param uploadId マルチパートアップロードID
+   * @param parts 各パートの情報（パート番号とETag）
+   * @returns 動画キーとアップロード完了オブジェクトのURL
+   */
+  public async completeMultipartUpload(
+    videoKey: string,
+    uploadId: string,
+    parts: Array<{ partNumber: number; eTag: string }>,
+  ): Promise<{ videoKey: string; location: string }> {
+    try {
+      return await this.apiPost<
+        { videoKey: string; location: string },
+        {
+          videoKey: string;
+          uploadId: string;
+          parts: Array<{ partNumber: number; eTag: string }>;
+        }
+      >("/videos/multipart/complete", {
+        videoKey,
+        uploadId,
+        parts,
+      });
+    } catch (error) {
+      console.error("マルチパートアップロード完了に失敗しました:", error);
+
+      if (error instanceof Error) {
+        throw new Error(
+          `マルチパートアップロード完了に失敗しました: ${error.message}`,
+        );
+      } else {
+        throw new Error("マルチパートアップロード完了に失敗しました");
+      }
+    }
+  }
+
+  /**
+   * マルチパートアップロードを中断する
+   *
+   * アップロード失敗時に呼び出し、アップロード済みパートを破棄する。
+   *
+   * @param videoKey 動画キー
+   * @param uploadId マルチパートアップロードID
+   * @returns 中断成功フラグ
+   */
+  public async abortMultipartUpload(
+    videoKey: string,
+    uploadId: string,
+  ): Promise<{ aborted: boolean }> {
+    try {
+      return await this.apiPost<
+        { aborted: boolean },
+        { videoKey: string; uploadId: string }
+      >("/videos/multipart/abort", {
+        videoKey,
+        uploadId,
+      });
+    } catch (error) {
+      // 中断処理の失敗は致命的ではないため、警告ログのみ出力して握りつぶす
+      console.warn("マルチパートアップロード中断に失敗しました:", error);
+      return { aborted: false };
     }
   }
 

--- a/frontend/src/services/__tests__/ApiService.video.test.ts
+++ b/frontend/src/services/__tests__/ApiService.video.test.ts
@@ -8,7 +8,9 @@ jest.mock("aws-amplify/api", () => ({
 jest.mock("../ApiService", () => ({
   ApiService: {
     getInstance: jest.fn(() => ({
-      getVideoUploadUrl: jest.fn(),
+      createMultipartUpload: jest.fn(),
+      completeMultipartUpload: jest.fn(),
+      abortMultipartUpload: jest.fn(),
     })),
   },
 }));
@@ -17,7 +19,9 @@ import { ApiService } from "../ApiService";
 
 describe("ApiService - ビデオ関連機能のテスト", () => {
   let apiService: {
-    getVideoUploadUrl: jest.Mock;
+    createMultipartUpload: jest.Mock;
+    completeMultipartUpload: jest.Mock;
+    abortMultipartUpload: jest.Mock;
   };
 
   beforeEach(() => {
@@ -25,45 +29,92 @@ describe("ApiService - ビデオ関連機能のテスト", () => {
     jest.clearAllMocks();
   });
 
-  describe("getVideoUploadUrl", () => {
-    it("署名付きURLの取得に成功するとき", async () => {
-      // モックレスポンスの設定
+  describe("createMultipartUpload", () => {
+    it("マルチパートアップロード開始に成功するとき", async () => {
+      // モックレスポンスの設定（25パート分のURLを想定）
       const mockResponse = {
-        uploadUrl:
-          "https://example-bucket.s3.amazonaws.com/videos/test-session-id/test-video.webm",
-        videoKey: "videos/test-session-id/test-video.webm",
-        expiresIn: 600,
+        uploadId: "test-upload-id",
+        videoKey: "videos/test-session-id/recording.mp4",
+        partUrls: [
+          { partNumber: 1, url: "https://example-bucket.s3.amazonaws.com/part1" },
+          { partNumber: 2, url: "https://example-bucket.s3.amazonaws.com/part2" },
+        ],
+        expiresIn: 3600,
       };
 
-      // ApiServiceのモック設定
-      apiService.getVideoUploadUrl.mockResolvedValue(mockResponse);
+      apiService.createMultipartUpload.mockResolvedValue(mockResponse);
 
-      // 関数の実行
-      const result = await apiService.getVideoUploadUrl(
+      const result = await apiService.createMultipartUpload(
         "test-session-id",
-        "video/webm",
-        "test-video.webm",
+        "video/mp4",
+        2,
+        "recording.mp4",
       );
 
-      // 関数が正しく呼び出されたことの検証
-      expect(apiService.getVideoUploadUrl).toHaveBeenCalledWith(
+      // 引数の順序が正しいことの検証（sessionId, contentType, partCount, fileName）
+      expect(apiService.createMultipartUpload).toHaveBeenCalledWith(
         "test-session-id",
-        "video/webm",
-        "test-video.webm",
+        "video/mp4",
+        2,
+        "recording.mp4",
       );
-
-      // 結果が正しいことの検証
       expect(result).toEqual(mockResponse);
+      expect(result.partUrls).toHaveLength(2);
     });
 
     it("エラーが発生するとき", async () => {
-      // エラーの設定
-      apiService.getVideoUploadUrl.mockRejectedValue(new Error("APIエラー"));
+      apiService.createMultipartUpload.mockRejectedValue(
+        new Error("マルチパート開始エラー"),
+      );
 
-      // 関数の実行とエラーの検証
       await expect(
-        apiService.getVideoUploadUrl("test-session-id", "video/webm"),
-      ).rejects.toThrow("APIエラー");
+        apiService.createMultipartUpload("test-session-id", "video/mp4", 2),
+      ).rejects.toThrow("マルチパート開始エラー");
+    });
+  });
+
+  describe("completeMultipartUpload", () => {
+    it("マルチパートアップロード完了に成功するとき", async () => {
+      const mockResponse = {
+        videoKey: "videos/test-session-id/recording.mp4",
+        location: "https://example-bucket.s3.amazonaws.com/recording.mp4",
+      };
+
+      apiService.completeMultipartUpload.mockResolvedValue(mockResponse);
+
+      const parts = [
+        { partNumber: 1, eTag: '"etag1"' },
+        { partNumber: 2, eTag: '"etag2"' },
+      ];
+      const result = await apiService.completeMultipartUpload(
+        "videos/test-session-id/recording.mp4",
+        "test-upload-id",
+        parts,
+      );
+
+      expect(apiService.completeMultipartUpload).toHaveBeenCalledWith(
+        "videos/test-session-id/recording.mp4",
+        "test-upload-id",
+        parts,
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe("abortMultipartUpload", () => {
+    it("マルチパートアップロード中断に成功するとき", async () => {
+      apiService.abortMultipartUpload.mockResolvedValue({ aborted: true });
+
+      const result = await apiService.abortMultipartUpload(
+        "videos/test-session-id/recording.mp4",
+        "test-upload-id",
+      );
+
+      expect(apiService.abortMultipartUpload).toHaveBeenCalledWith(
+        "videos/test-session-id/recording.mp4",
+        "test-upload-id",
+      );
+      expect(result).toEqual({ aborted: true });
     });
   });
 });

--- a/frontend/src/tests/e2e/video-multipart-upload.spec.ts
+++ b/frontend/src/tests/e2e/video-multipart-upload.spec.ts
@@ -1,0 +1,355 @@
+/**
+ * E2Eテスト: セッション録画のマルチパートアップロード
+ *
+ * GitHub Issue #68「セッション録画のS3アップロードが EntityTooLarge で失敗する」の
+ * 抜本対策として導入したマルチパートアップロードのE2Eテスト。
+ * dev環境（CloudFront / API Gateway）への接続を伴う統合テスト。
+ *
+ * 検証観点:
+ * 1. /videos/multipart/create が認証付きで uploadId と partUrls を返すこと
+ * 2. 返却された署名付きURLに実データをPUTでき、ETagが取得できること
+ *    （S3バケットCORSの exposedHeaders に ETag が公開されていることの検証も兼ねる）
+ * 3. /videos/multipart/complete でパート結合が成功すること
+ * 4. 不正リクエスト（partCount欠如）が400で弾かれること
+ * 5. 旧 /videos/upload-url が削除され、マルチパートに一本化されていること
+ * 6. 中断（abort）後に complete を呼んでも結合が成功しないこと（異常系）
+ *
+ * 【重要】実行前提:
+ * - 本テストは E2E_API_GATEWAY_ENDPOINT が指すデプロイ済み環境（dev等）に対して実行する。
+ *   検証観点5（旧エンドポイント削除の確認）は、本変更を含むスタックを
+ *   `npm run deploy:dev` でデプロイした後でないと正しく評価できない。
+ *   デプロイ前に実行すると旧エンドポイントがまだ生きており、誤った合否になる。
+ * - CIには未組み込みのため手動実行を想定。実行コマンド:
+ *   `cd frontend && npx playwright test video-multipart-upload.spec.ts --project=chromium`
+ *
+ * 設計上の注意:
+ * - ブラウザは実カメラにアクセスできないため、録画動画の実生成はE2Eでは検証しない。
+ *   代わりに、ログイン済みブラウザコンテキストで取得した本物のCognito IDトークンを使い、
+ *   デプロイ済みのマルチパートAPIをAPIレイヤーで end-to-end に検証する。
+ * - 認証トークンはAmplifyがlocalStorageに保存したものをアプリのコンテキスト内から取得する。
+ *   キー構造への直接依存を避けるため、CognitoのidTokenキーをパターン検索で取得する。
+ */
+import { test, expect, Page } from "@playwright/test";
+import { login } from "./helpers";
+
+// APIエンドポイント（アプリのビルド時環境変数と同一のものをテスト環境変数から取得）
+const API_ENDPOINT = (process.env.E2E_API_GATEWAY_ENDPOINT || "").replace(
+  /\/$/,
+  "",
+);
+
+// S3マルチパートアップロードの最小パートサイズは5MB。
+// 複数パートの結合を検証するため、1パート目は5MB以上のデータを用意する。
+const PART_SIZE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * ログイン済みブラウザコンテキストからCognito IDトークンを取得する
+ *
+ * Amplify v6はCognitoのトークンを localStorage に
+ * `CognitoIdentityServiceProvider.<clientId>.<username>.idToken` 形式で保存する。
+ * キー構造の細部に依存しないよう、`.idToken` で終わるキーをパターン検索で取得する。
+ *
+ * @param page Playwrightのページオブジェクト
+ * @returns Cognito IDトークン文字列
+ */
+async function getIdToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (
+        key &&
+        key.startsWith("CognitoIdentityServiceProvider") &&
+        key.endsWith(".idToken")
+      ) {
+        return window.localStorage.getItem(key);
+      }
+    }
+    return null;
+  });
+
+  if (!token) {
+    throw new Error(
+      "Cognito IDトークンが取得できませんでした。ログインが完了しているか確認してください。",
+    );
+  }
+  return token;
+}
+
+test.beforeEach(async ({ page }) => {
+  // APIエンドポイントが設定されていない場合はテストを失敗させ、原因を明示する
+  expect(
+    API_ENDPOINT,
+    "E2E_API_GATEWAY_ENDPOINT が .env.test に設定されている必要があります",
+  ).not.toBe("");
+
+  await login(page);
+});
+
+test.describe("セッション録画のマルチパートアップロード", () => {
+  test("マルチパートアップロードのフルフロー（create→PUT→complete）が成功すること", async ({
+    page,
+  }) => {
+    const idToken = await getIdToken(page);
+    const sessionId = `e2e-multipart-${Date.now()}`;
+
+    // --- ステップ1: マルチパートアップロード開始（2パート分のURLを要求） ---
+    const createResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/create`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          sessionId,
+          contentType: "video/mp4",
+          partCount: 2,
+          fileName: "e2e-recording.mp4",
+        },
+      },
+    );
+
+    expect(
+      createResponse.ok(),
+      `create失敗: status=${createResponse.status()}`,
+    ).toBeTruthy();
+
+    const createBody = await createResponse.json();
+    expect(createBody.uploadId, "uploadIdが返却されること").toBeTruthy();
+    expect(createBody.videoKey, "videoKeyが返却されること").toBeTruthy();
+    expect(
+      Array.isArray(createBody.partUrls),
+      "partUrlsが配列であること",
+    ).toBeTruthy();
+    expect(createBody.partUrls).toHaveLength(2);
+    expect(createBody.partUrls[0].partNumber).toBe(1);
+    expect(createBody.partUrls[0].url).toContain("http");
+
+    const { uploadId, videoKey, partUrls } = createBody;
+
+    // --- ステップ2: 各パートを署名付きURLにPUTしてETagを取得 ---
+    // S3仕様上、最後のパート以外は5MB以上必要。
+    // 1パート目: 5MBちょうど、2パート目: 1KB（最終パートは小さくてもよい）。
+    // ASCII文字列はUTF-8で1文字=1バイトになるため、文字数=バイト数として扱える。
+    const part1Data = "a".repeat(PART_SIZE_BYTES);
+    const part2Data = "a".repeat(1024);
+    const partPayloads = [part1Data, part2Data];
+
+    const uploadedParts: Array<{ partNumber: number; eTag: string }> = [];
+
+    for (const { partNumber, url } of partUrls) {
+      const putResponse = await page.request.put(url, {
+        headers: { "Content-Type": "application/octet-stream" },
+        data: partPayloads[partNumber - 1],
+      });
+
+      expect(
+        putResponse.ok(),
+        `パート${partNumber}のPUT失敗: status=${putResponse.status()}`,
+      ).toBeTruthy();
+
+      // S3はパートアップロードのレスポンスでETagヘッダーを返す。
+      // バケットCORSの exposedHeaders に ETag が公開されていないと取得できない。
+      const eTag = putResponse.headers()["etag"];
+      expect(eTag, `パート${partNumber}のETagが取得できること`).toBeTruthy();
+
+      uploadedParts.push({ partNumber, eTag });
+    }
+
+    // --- ステップ3: マルチパートアップロード完了（パート結合） ---
+    const completeResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/complete`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          videoKey,
+          uploadId,
+          parts: uploadedParts,
+        },
+      },
+    );
+
+    expect(
+      completeResponse.ok(),
+      `complete失敗: status=${completeResponse.status()}`,
+    ).toBeTruthy();
+
+    const completeBody = await completeResponse.json();
+    expect(completeBody.videoKey, "完了レスポンスにvideoKeyが含まれること").toBe(
+      videoKey,
+    );
+  });
+
+  test("partCountを欠いた不正なcreateリクエストは400で弾かれること", async ({
+    page,
+  }) => {
+    const idToken = await getIdToken(page);
+
+    const response = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/create`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          sessionId: `e2e-invalid-${Date.now()}`,
+          contentType: "video/mp4",
+          // partCount を意図的に欠落させる
+        },
+      },
+    );
+
+    expect(
+      response.status(),
+      "partCount欠如のリクエストは400を返すこと",
+    ).toBe(400);
+  });
+
+  test("中断（abort）リクエストが成功すること", async ({ page }) => {
+    const idToken = await getIdToken(page);
+    const sessionId = `e2e-abort-${Date.now()}`;
+
+    // マルチパートアップロードを開始
+    const createResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/create`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          sessionId,
+          contentType: "video/mp4",
+          partCount: 1,
+          fileName: "e2e-abort.mp4",
+        },
+      },
+    );
+    expect(createResponse.ok()).toBeTruthy();
+    const { uploadId, videoKey } = await createResponse.json();
+
+    // パートをアップロードせずに中断
+    const abortResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/abort`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: { videoKey, uploadId },
+      },
+    );
+
+    expect(
+      abortResponse.ok(),
+      `abort失敗: status=${abortResponse.status()}`,
+    ).toBeTruthy();
+    const abortBody = await abortResponse.json();
+    expect(abortBody.aborted, "中断成功フラグが返ること").toBe(true);
+  });
+
+  test("中断（abort）後に complete を呼んでも結合が成功しないこと", async ({
+    page,
+  }) => {
+    const idToken = await getIdToken(page);
+    const sessionId = `e2e-abort-then-complete-${Date.now()}`;
+
+    // マルチパートアップロードを開始
+    const createResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/create`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          sessionId,
+          contentType: "video/mp4",
+          partCount: 1,
+          fileName: "e2e-abort-then-complete.mp4",
+        },
+      },
+    );
+    expect(createResponse.ok()).toBeTruthy();
+    const { uploadId, videoKey, partUrls } = await createResponse.json();
+
+    // 1パート目をアップロードしてETagを取得（5MBちょうど）
+    const putResponse = await page.request.put(partUrls[0].url, {
+      headers: { "Content-Type": "application/octet-stream" },
+      data: "a".repeat(PART_SIZE_BYTES),
+    });
+    expect(putResponse.ok(), "パートのPUTが成功すること").toBeTruthy();
+    const eTag = putResponse.headers()["etag"];
+    expect(eTag, "ETagが取得できること").toBeTruthy();
+
+    // 中断してアップロード済みパートを破棄
+    const abortResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/abort`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: { videoKey, uploadId },
+      },
+    );
+    expect(abortResponse.ok(), "abortが成功すること").toBeTruthy();
+
+    // 中断済みのuploadIdに対してcompleteを呼ぶ。
+    // S3は中断済みのマルチパートアップロードを認識しないため結合は成功しない
+    // （NoSuchUpload相当のエラーとなり、completeエンドポイントは2xxを返さない）。
+    const completeResponse = await page.request.post(
+      `${API_ENDPOINT}/videos/multipart/complete`,
+      {
+        headers: {
+          Authorization: idToken,
+          "Content-Type": "application/json",
+        },
+        data: {
+          videoKey,
+          uploadId,
+          parts: [{ partNumber: 1, eTag }],
+        },
+      },
+    );
+
+    expect(
+      completeResponse.ok(),
+      "中断済みアップロードのcompleteは成功しないこと",
+    ).toBeFalsy();
+  });
+
+  test("旧 /videos/upload-url エンドポイントが削除され応答しないこと", async ({
+    page,
+  }) => {
+    const idToken = await getIdToken(page);
+
+    // 旧エンドポイントはマルチパート統一により削除済み。
+    // API Gatewayに当該ルートが存在しないため、成功レスポンス（2xx）は返らない。
+    // 未定義ルートに対する具体的なステータスコード（403/404/500等）はAPI Gatewayの
+    // 認証・GatewayResponse設定に依存するため、ステータスコードの厳密値ではなく
+    // 「成功しないこと（録画用URLが発行されないこと）」を検証する。
+    const response = await page.request.get(
+      `${API_ENDPOINT}/videos/upload-url?sessionId=e2e-legacy&contentType=video/mp4`,
+      {
+        headers: { Authorization: idToken },
+      },
+    );
+
+    expect(
+      response.ok(),
+      "削除済みの旧エンドポイントは成功レスポンスを返さないこと",
+    ).toBeFalsy();
+
+    // 万一2xxでなくても、署名付きURL（uploadUrl）が含まれていないことを二重に確認する
+    const bodyText = await response.text();
+    expect(
+      bodyText.includes("uploadUrl"),
+      "旧エンドポイントが署名付きURLを発行していないこと",
+    ).toBeFalsy();
+  });
+});

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -483,13 +483,25 @@ export interface VideoAnalysisResult {
 // ============================================================
 
 /**
+ * リファレンスチェックの評価区分
+ * - "appropriate"    : 発言が参照資料の内容に沿っており、正確な情報提供ができている
+ * - "issue"          : 発言が参照資料の内容と矛盾している、または誤った情報を含んでいる
+ * - "not_applicable" : 挨拶・一般的な進行・意思表示など、参照資料の正誤を問えない発言
+ */
+export type ReferenceCheckEvaluation =
+  | "appropriate"
+  | "issue"
+  | "not_applicable";
+
+/**
  * リファレンスチェックのメッセージ情報
  */
 export interface ReferenceCheckMessage {
   message: string;
   relatedDocument?: string;
   reviewComment?: string;
-  related: boolean;
+  /** 評価区分（3分類） */
+  evaluation: ReferenceCheckEvaluation;
 }
 
 /**
@@ -498,6 +510,12 @@ export interface ReferenceCheckMessage {
 export interface ReferenceCheckSummary {
   totalMessages: number;
   checkedMessages: number;
+  /** 適切な発言数 */
+  appropriateCount?: number;
+  /** 評価対象外の発言数 */
+  notApplicableCount?: number;
+  /** 問題ありの発言数 */
+  issueCount?: number;
 }
 
 /**


### PR DESCRIPTION
## 概要

リアルタイムスコアリングのトークン不足（Issue #67）とセッション録画のアップロードサイズ制限（Issue #68）を修正し、あわせて参照チェック機能のAgentCoreトークン401対策を取り込みます。

## 変更内容

### Issue #67: リアルタイムスコアリングエージェントの `max_tokens` 不足
- `cdk/agents/realtime-scoring/agent.py` の `max_tokens` を `1024` → `2048` に引き上げ
- structured output と AgentCore Memory の履歴取得でトークンが不足し、全ターンで `AGENT_ERROR` が発生していた問題を解消
- 他エージェント（audio-analysis: 2048, feedback-analysis: 4096）と整合

### Issue #68: セッション録画のS3アップロードが `EntityTooLarge` で失敗
- 署名付きPOST方式を廃止し、**マルチパートアップロードに一本化**
- 20分超の長時間セッション（動画+音声で200MB超）でもS3のサイズ制限に到達しない
- 追加エンドポイント: `POST /videos/multipart/{create,complete,abort}`
- 未完了マルチパートを1日後に自動削除するS3ライフサイクルルールを追加
- マルチパート用署名付きURLの有効期限を3600秒に設定
- 旧 `/videos/upload-url` とフロントエンドのPOSTアップロード経路を削除

### 参照チェックのAgentCoreトークン401対策
- 失効間近トークンを先回り更新（残り2分で `forceRefresh`）
- AgentCore Runtime が401を返した場合にトークンを強制更新して1回リトライ
- 関連する型定義・i18n・ユニットテストを追加

## テスト

- フロントエンドユニットテスト: 28スイート / 214件 全パス（`npm run test`）
- リント: エラーなし（`npm run lint`）
- i18n検証: 日英整合OK（`npm run validate-i18n`）
- Python構文チェック: OK
- CDK synth (dev): 正常合成
- E2Eテスト（dev環境）: マルチパート4件 + 録画トグル5件 全パス
  - `frontend/src/tests/e2e/video-multipart-upload.spec.ts` を新規追加
  - マルチパートのフルフロー（create→各パートPUT→complete）、ETag取得、abort、旧エンドポイント削除を検証

## デプロイ

- dev環境へデプロイ済み・動作確認済み
- AWS環境への反映はCDK経由（`npm run deploy:dev` 等）

## 補足

- 本PRには参照チェック機能のトークン対策（別作業分）も含みます。
- `.env.test` はgit管理外のため、E2E実行には `E2E_API_GATEWAY_ENDPOINT` 等の環境変数設定が必要です（CIのJestテストには影響しません）。
