### PR TITLE
Repair broken lockfiles failing npm ci and CDK CLI schema mismatch

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -38,7 +38,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "25.5.0",
-        "aws-cdk": "2.1114.1",
+        "aws-cdk": "2.1139.0",
         "aws-cdk-lib": "^2.262.0",
         "cdk-nag": "^2.37.55",
         "jest": "^30.3.0",
@@ -346,7 +346,6 @@
         "semver"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "^1.5.0",
         "semver": "^7.8.5"
@@ -968,7 +967,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1019.0.tgz",
       "integrity": "sha512-RNBtkQQ5IUqTdxaAe7ADwlJ/1qqW5kONLD1Mxr7PUWteEQwYR9ZJYscDul2qNkCWhu/vMKhk+qwJKPkdu2TNzA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1173,7 +1171,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1019.0.tgz",
       "integrity": "sha512-fVjti0Z8DpsSOv5i2eaigg536FTPOqSBjeVBAaitGMdqLaOWGsGq1eVQWZ6fcfQadS2bRfA2lpxRQsJIC40/5w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1696,7 +1693,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1019.0.tgz",
       "integrity": "sha512-0pb9x7PPhS4oEi4c0rL3vzQQoXA4cWKtPuGga/UfVYLZ68yrqdq0NDKg0fr55qzdhNvWFCpmGx73g9Iyy03kkA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -2769,7 +2765,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
       "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -6379,7 +6374,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -7510,7 +7504,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8522,7 +8515,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -9047,9 +9039,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1114.1.tgz",
-      "integrity": "sha512-jMaKPWQQs1G6AbhfCQG2zGrgAhTxzP0jn4T2CuwONuvcV374dMPhfC/LBAv48ruSOgpCK9x6V1xeO/aH3EchAA==",
+      "version": "2.1139.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1139.0.tgz",
+      "integrity": "sha512-JVvrVvY2fZasf4gW4fvF7x1QMXUtvvGjnTKDe6cppWR1FUG8XgRF/S7xOkcdPVcdEf4R5ss7QdEfNVI7xiDomQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9078,7 +9070,6 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
@@ -9396,7 +9387,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -9518,6 +9508,7 @@
       "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.28.tgz",
       "integrity": "sha512-l+yybyZLV7zTD6EuGxoXsilpER1ctMCpdOqjSYNigJJma39ha85fzCtYccPx06oR1u7uCQLOcUAFFzvfXVBmuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "^2.0.7",
         "individual": "^3.0.0"
@@ -9570,7 +9561,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -9691,7 +9681,6 @@
       "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
       "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "aws-cdk-lib": "^2.176.0",
         "constructs": "^10.0.5"
@@ -9875,8 +9864,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
       "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -10228,7 +10216,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
@@ -10630,7 +10619,8 @@
     "node_modules/individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
-      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g=="
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==",
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -10849,7 +10839,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -11533,7 +11522,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -11970,6 +11960,7 @@
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
       "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "minimist": "^1.2.5",
@@ -11989,6 +11980,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -12003,6 +11995,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
@@ -12342,6 +12335,7 @@
         "yargs"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "case": "^1.6.3",
@@ -12371,12 +12365,14 @@
     "node_modules/projen/node_modules/@iarna/toml": {
       "version": "2.2.5",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/projen/node_modules/@oozcitak/dom": {
       "version": "1.15.10",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/url": "1.0.4",
@@ -12390,6 +12386,7 @@
       "version": "1.0.8",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oozcitak/util": "8.3.8"
       },
@@ -12401,6 +12398,7 @@
       "version": "1.0.4",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/util": "8.3.8"
@@ -12413,6 +12411,7 @@
       "version": "8.3.8",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0"
       }
@@ -12421,6 +12420,7 @@
       "version": "5.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12429,6 +12429,7 @@
       "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12443,6 +12444,7 @@
       "version": "1.0.10",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -12450,17 +12452,20 @@
     "node_modules/projen/node_modules/array-timsort": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/brace-expansion": {
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -12469,6 +12474,7 @@
       "version": "1.6.3",
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -12477,6 +12483,7 @@
       "version": "4.1.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12492,6 +12499,7 @@
       "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -12505,6 +12513,7 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12515,12 +12524,14 @@
     "node_modules/projen/node_modules/color-name": {
       "version": "1.1.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/comment-json": {
       "version": "4.2.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -12535,27 +12546,32 @@
     "node_modules/projen/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/conventional-changelog-config-spec": {
       "version": "2.1.0",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/core-util-is": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/escalade": {
       "version": "3.1.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12564,6 +12580,7 @@
       "version": "4.0.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -12575,17 +12592,20 @@
     "node_modules/projen/node_modules/fast-json-patch": {
       "version": "3.1.1",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/fs.realpath": {
       "version": "1.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/projen/node_modules/function-bind": {
       "version": "1.1.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -12594,6 +12614,7 @@
       "version": "2.0.5",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -12602,6 +12623,7 @@
       "version": "8.1.0",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12620,6 +12642,7 @@
       "version": "5.1.6",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -12631,6 +12654,7 @@
       "version": "4.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12639,6 +12663,7 @@
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12647,6 +12672,7 @@
       "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -12658,6 +12684,7 @@
       "version": "1.0.6",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12666,12 +12693,14 @@
     "node_modules/projen/node_modules/inherits": {
       "version": "2.0.4",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/projen/node_modules/ini": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12680,6 +12709,7 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -12688,6 +12718,7 @@
       "version": "2.14.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -12702,6 +12733,7 @@
       "version": "3.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12710,6 +12742,7 @@
       "version": "3.14.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -12722,6 +12755,7 @@
       "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12733,6 +12767,7 @@
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -12742,6 +12777,7 @@
       "version": "1.2.8",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -12750,6 +12786,7 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -12758,6 +12795,7 @@
       "version": "1.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12765,11 +12803,13 @@
     "node_modules/projen/node_modules/path-parse": {
       "version": "1.0.7",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/projen/node_modules/rechoir": {
       "version": "0.6.2",
       "inBundle": true,
+      "peer": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -12781,6 +12821,7 @@
       "version": "1.6.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -12789,6 +12830,7 @@
       "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12797,6 +12839,7 @@
       "version": "1.22.8",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -12813,6 +12856,7 @@
       "version": "7.6.2",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12824,6 +12868,7 @@
       "version": "0.8.5",
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -12840,6 +12885,7 @@
       "version": "7.2.3",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12859,6 +12905,7 @@
       "version": "0.3.4",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -12873,12 +12920,14 @@
     "node_modules/projen/node_modules/sprintf-js": {
       "version": "1.0.3",
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/projen/node_modules/string-width": {
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12892,6 +12941,7 @@
       "version": "6.0.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12903,6 +12953,7 @@
       "version": "7.2.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12914,6 +12965,7 @@
       "version": "1.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12925,6 +12977,7 @@
       "version": "7.0.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12940,12 +12993,14 @@
     "node_modules/projen/node_modules/wrappy": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/projen/node_modules/xmlbuilder2": {
       "version": "3.1.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oozcitak/dom": "1.15.10",
         "@oozcitak/infra": "1.0.8",
@@ -12960,6 +13015,7 @@
       "version": "5.0.8",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12968,6 +13024,7 @@
       "version": "2.4.5",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12979,6 +13036,7 @@
       "version": "17.7.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -12996,6 +13054,7 @@
       "version": "21.1.1",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -13767,6 +13826,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "3"
       }
@@ -13776,6 +13836,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13876,7 +13937,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13959,7 +14019,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14339,7 +14398,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.17.tgz",
       "integrity": "sha512-8hQzQ/kMOIFbwOgPrm9Sf9rtFHpFUMy4HvN0yEB0spw14aYi0uT5xG5CE2DB9cd51GWNsz+DNO7se1kztHMKnw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "25.5.0",
-    "aws-cdk": "2.1114.1",
+    "aws-cdk": "2.1139.0",
     "aws-cdk-lib": "^2.262.0",
     "cdk-nag": "^2.37.55",
     "jest": "^30.3.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -181,7 +181,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.1.tgz",
       "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.973.1",
@@ -1978,7 +1977,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2539,7 +2537,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2563,7 +2560,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2666,7 +2662,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2710,7 +2705,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3637,7 +3631,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
       "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.9",
@@ -4885,6 +4878,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -6313,7 +6329,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -6509,7 +6526,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6632,7 +6648,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -7197,7 +7212,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7330,7 +7344,6 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.3.tgz",
       "integrity": "sha512-yWuvctncVzSI5K40k2LiZTTKu6p1O7YpbmFfbM9luAFssUj2P2DmgJgs2IQ0ArpJTi++QrAT5L4F60qxTpGTIA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.93",
         "@aws-amplify/api": "6.3.24",
@@ -7546,7 +7559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7673,7 +7685,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -8065,7 +8076,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8180,7 +8192,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8975,7 +8986,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -9343,7 +9353,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -10341,7 +10350,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -10793,6 +10801,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11494,6 +11503,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11509,6 +11519,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11521,7 +11532,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -11770,7 +11782,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11790,7 +11801,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12584,8 +12594,7 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -12628,7 +12637,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12942,7 +12950,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13204,7 +13211,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13559,7 +13565,6 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -13665,7 +13670,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Problem

Deploying `main` via `bin.sh` (CloudFormation → CodeBuild) fails deterministically for all users, due to two independent issues in committed files:

1. **`frontend/package-lock.json` is internally inconsistent** — `@rolldown/binding-wasm32-wasi@1.0.3` (an optional platform dep of `vite` → `rolldown`) requires `@emnapi/core@1.10.0` / `@emnapi/runtime@1.10.0`, but the lockfile only contains `1.11.3`. Since `npm ci` validates the entire lock tree (including optional deps for other platforms), it fails on every OS/arch:
   ```
   npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
   npm error Missing: @emnapi/core@1.10.0 from lock file
   ```
2. **CDK CLI / library schema mismatch** — `cdk/package.json` pins `aws-cdk@2.1114.1` (reads cloud assembly schema up to 53.x) while `aws-cdk-lib@^2.262.0` emits schema 54.0.0, so `npx cdk bootstrap` fails:
   ```
   Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0.
   You need at least CLI version 2.1133.0 to read this manifest.
   ```

## Changes

- Regenerate `frontend/package-lock.json` (`npm install --package-lock-only`; no `package.json` changes)
- Bump `aws-cdk` to `2.1139.0` (exact pin, matching existing convention) and regenerate `cdk/package-lock.json`

## Testing

- `npm ci` now succeeds in a CodeBuild-equivalent container (`docker run --platform linux/arm64 node:22`) for both `frontend/` and `cdk/` — previously reproduced the exact failure
- `npx cdk synth` succeeds with the updated CLI (no schema mismatch)
