### PR TITLE
fix(cdk): index.html にキャッシュ制御を追加しアップデート後の古いフロント配信を防ぐ (#98)

### DIFF
--- a/cdk/lib/constructs/web.ts
+++ b/cdk/lib/constructs/web.ts
@@ -37,6 +37,32 @@ export class Web extends Construct {
       versioned: false,
     };
 
+    // #98: index.html（および errorResponses 経由で index.html に書き換えられる
+    // SPA ディープリンク応答）に Cache-Control: no-cache を付与するためのポリシー。
+    // deploy-time-build の NodejsBuild は S3 へ `aws s3 sync` する際に Cache-Control を
+    // 付けられない（NodejsBuildProps に cacheControl が存在しない）ため、オリジンではなく
+    // CloudFront のレスポンスヘッダーポリシーで注入する。これにより、アップデートのデプロイ後に
+    // 古い index.html が最大 1 日（CACHING_OPTIMIZED の defaultTtl）配信され続ける問題を防ぐ。
+    // no-cache = 毎回オリジンへ再検証（ETag/Last-Modified）。not-store ではないため 304 で軽量。
+    const htmlResponseHeadersPolicy = new ResponseHeadersPolicy(this, 'HtmlNoCachePolicy', {
+      customHeadersBehavior: {
+        customHeaders: [
+          { header: 'Cache-Control', value: 'no-cache', override: true },
+        ],
+      },
+    });
+
+    // #98: ファイル名にコンテンツハッシュを含む assets/* は long-term immutable キャッシュにする。
+    // Vite は assets/ 配下へハッシュ付きファイル名で出力するため、内容が変われば URL も変わり、
+    // 古いキャッシュが参照されることはない。
+    const assetsResponseHeadersPolicy = new ResponseHeadersPolicy(this, 'AssetsImmutablePolicy', {
+      customHeadersBehavior: {
+        customHeaders: [
+          { header: 'Cache-Control', value: 'public, max-age=31536000, immutable', override: true },
+        ],
+      },
+    });
+
     const { cloudFrontWebDistribution, s3BucketInterface } = new CloudFrontToS3(
       this,
       'Web',
@@ -46,6 +72,11 @@ export class Web extends Construct {
         bucketProps: commonBucketProps,
         cloudFrontLoggingBucketProps: commonBucketProps,
         cloudFrontDistributionProps: {
+          // デフォルトビヘイビア（/*）に no-cache を適用。index.html 本体に加え、
+          // errorResponses(403/404 -> /index.html) 経由の SPA ディープリンク応答もここを通る。
+          defaultBehavior: {
+            responseHeadersPolicy: htmlResponseHeadersPolicy,
+          },
           errorResponses: [
             {
               httpStatus: 403,
@@ -59,6 +90,19 @@ export class Web extends Construct {
             },
           ],
         },
+      }
+    );
+
+    // #98: assets/* だけは immutable な長期キャッシュにする専用ビヘイビアを追加。
+    // オリジンはデフォルトビヘイビアと同じ Web バケット（OAC 経由）。
+    cloudFrontWebDistribution.addBehavior(
+      '/assets/*',
+      S3BucketOrigin.withOriginAccessControl(s3BucketInterface),
+      {
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: CachePolicy.CACHING_OPTIMIZED,
+        allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+        responseHeadersPolicy: assetsResponseHeadersPolicy,
       }
     );
 


### PR DESCRIPTION
## 概要 / Summary

Fixes #98

アップデートのデプロイ完了後もブラウザに古いフロントエンド（`index.html`）が最大 1 日配信され続ける問題を修正します。`index.html` に `Cache-Control` が付与されておらず、CloudFront (`CACHING_OPTIMIZED`, defaultTtl=1日) と ブラウザのヒューリスティックキャッシュの両方で古い版が保持されるのが原因です。#93 (Transcribe のブラウザ直接接続化 / 旧 WebSocket バックエンド削除) が引き金となり、「バックエンド新 / フロント旧キャッシュ」のズレがマイク不動作＝「ネットワークエラー」として顕在化しました（キャッシュ欠陥自体は #93 以前から潜在）。

## 原因の要点

- `cdk/lib/constructs/web.ts` の `CloudFrontToS3` が既定の `CACHING_OPTIMIZED`（defaultTtl=1日）を使用し、S3 オリジンが `Cache-Control` を返さないため `index.html` がエッジで最大 1 日保持される。
- `errorResponses`（403/404 → `/index.html`）経由の SPA ディープリンクも同じ経路で古い版を配信する。
- Issue の提案1（`NodejsBuild` に `cacheControl` を指定）は **`deploy-time-build` の現行 API では不可**（`NodejsBuildProps` に `cacheControl` が無く、内部で `aws s3 sync` するため `Cache-Control` を付けられない）。そのため **CloudFront の `ResponseHeadersPolicy` で注入**する方針を採用しました。

## 変更内容

`cdk/lib/constructs/web.ts` に `ResponseHeadersPolicy` を 2 つ追加し、CloudFront レスポンスヘッダーとして `Cache-Control` を注入します。

- **デフォルトビヘイビア（`/*`）**: `Cache-Control: no-cache`
  - `index.html` 本体に加え、`errorResponses`（403/404 → `/index.html`）経由の SPA ディープリンク応答もこのビヘイビアを通るためカバーされる。
  - `no-cache` は「キャッシュ禁止」ではなく「毎回オリジンへ再検証」。S3 の ETag により未変更なら 304 で軽量に返る。
- **`/assets/*` 専用ビヘイビア**: `Cache-Control: public, max-age=31536000, immutable`
  - Vite がコンテンツハッシュ付きファイル名で出力するため、長期 immutable キャッシュが安全。
  - キャッシュポリシーは既存の `CACHING_OPTIMIZED` を維持。

`avatars/*` ビヘイビアと `errorResponses` は既存挙動を維持しています。

## 検証 / Testing

Jetson (aarch64, Node 22.23.2) で以下を確認済み:

- `cd cdk && npm ci` → `npx tsc --noEmit` : **エラー 0**
- `Web` construct を単独 synth し、生成された CloudFormation テンプレートを検査:
  - `ResponseHeadersPolicy` が 2 つ生成される（`HtmlNoCachePolicy` = `Cache-Control: no-cache` / `AssetsImmutablePolicy` = `public, max-age=31536000, immutable`、いずれも `override: true`）
  - `DefaultCacheBehavior` が `HtmlNoCachePolicy` を参照
  - `/assets/*` ビヘイビアが `AssetsImmutablePolicy` + `CACHING_OPTIMIZED` を持ち、**S3 オリジンが保持されている**（`@aws-solutions-constructs` の `consolidateProps` deepmerge により `defaultBehavior.responseHeadersPolicy` だけを渡してもオリジンが消えないことを実テンプレートで確認）
  - `CustomErrorResponses`（403/404 → `/index.html`）が維持されている

> 注: 本番スタック全体の `cdk synth` は `aws-lambda-python-alpha` の Docker バンドリングに依存するため Docker のある CI 環境での実行を想定しています（本変更とは無関係）。

## 補足

Issue の提案2（`ConversationPage.tsx` の Transcribe 初期化失敗をすべて `network` に丸めている件をエラー種別ごとに出し分ける）は妥当な改善ですが、本 PR のスコープ外とし別途対応とします。