### PR TITLE
fix(ci): make GitHub Actions checks pass (frontend tests/lint + lambda pytest)

### DIFF
--- a/cdk/lambda/pytest.ini
+++ b/cdk/lambda/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# Use importlib import mode so that identically-named test packages
+# (e.g. scenarios/tests and sessions/tests, both packages named "tests")
+# do not collide under pytest's default "prepend" import mode.
+# Without this, collecting the second "tests" package raises
+# ModuleNotFoundError: No module named 'tests.<module>'.
+addopts = --import-mode=importlib

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,7 +8,7 @@ import tseslint from "typescript-eslint";
 const failOnWarning = process.env.ESLINT_FAIL_ON_WARNING === "true";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "coverage", "node_modules"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/frontend/src/__tests__/components/SessionHistoryList.test.tsx
+++ b/frontend/src/__tests__/components/SessionHistoryList.test.tsx
@@ -5,6 +5,27 @@ import "@testing-library/jest-dom";
 import SessionHistoryPage from "../../pages/history/SessionHistoryPage";
 import { ApiService } from "../../services/ApiService";
 
+/**
+ * NPC名と役職は SessionHistoryPage 内で
+ *   <Typography>{name}<Typography component="span"> ({role})</Typography></Typography>
+ * のように親要素とネストした span に分割してレンダリングされる。
+ * そのため getByText("テストNPC (銀行員)") では単一要素に一致せず失敗する。
+ * 要素の textContent（正規化後）で一致を判定するマッチャーを用意する。
+ */
+const combinedText = (expected: string) => {
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim();
+  return (_content: string, element: Element | null): boolean => {
+    if (!element) return false;
+    const own = normalize(element.textContent || "");
+    if (own !== expected) return false;
+    // 最も内側（子孫が同じテキストを持たない）要素のみに一致させ、重複ヒットを防ぐ
+    const childMatches = Array.from(element.children).some(
+      (child) => normalize(child.textContent || "") === expected,
+    );
+    return !childMatches;
+  };
+};
+
 // APIサービスのモック
 jest.mock("../../services/ApiService", () => {
   return {
@@ -131,8 +152,8 @@ describe("SessionHistoryPage コンポーネント", () => {
     });
 
     // セッション詳細の確認（NPC名は役職も含めて表示される）
-    expect(screen.getByText("テストNPC (銀行員)")).toBeInTheDocument();
-    expect(screen.getByText("山田太郎 (証券営業)")).toBeInTheDocument();
+    expect(screen.getByText(combinedText("テストNPC (銀行員)"))).toBeInTheDocument();
+    expect(screen.getByText(combinedText("山田太郎 (証券営業)"))).toBeInTheDocument();
 
     // ステータス表示の確認
     const completedChip = screen.getByText("完了");
@@ -170,8 +191,8 @@ describe("SessionHistoryPage コンポーネント", () => {
 
     // 全てのセッションが再表示されることを確認
     await waitFor(() => {
-      expect(screen.getByText("テストNPC (銀行員)")).toBeInTheDocument();
-      expect(screen.getByText("山田太郎 (証券営業)")).toBeInTheDocument();
+      expect(screen.getByText(combinedText("テストNPC (銀行員)"))).toBeInTheDocument();
+      expect(screen.getByText(combinedText("山田太郎 (証券営業)"))).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/conversation/AvatarStage.tsx
+++ b/frontend/src/components/conversation/AvatarStage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { VRMAvatarContainer } from "../avatar";
 import type { EmotionState } from "../../types/index";
@@ -35,7 +35,8 @@ const AvatarStage: React.FC<AvatarStageProps> = ({
   directEmotion,
   gesture,
   onEmotionChange,
-  npcName,
+  // npcName はインターフェースに残す（呼び出し側が指定）が、
+  // NPC名ラベルが非表示のため本コンポーネント内では未使用
 }) => {
   const { t } = useTranslation();
 

--- a/frontend/src/pages/ConversationPage.tsx
+++ b/frontend/src/pages/ConversationPage.tsx
@@ -56,18 +56,6 @@ import type { SlideImageInfo } from "../types/api";
 import { Dialog, DialogTitle, DialogContent } from "@mui/material";
 
 /**
- * 右パネル（ゴール・メトリクス等）の占有幅
- * RightPanelContainer の maxWidth(260px) + right(12px) + 余白(8px) = 280px
- */
-const RIGHT_PANEL_OFFSET = "280px";
-
-/**
- * 左側メトリクス・カメラ領域の占有幅
- * アバター非表示時にチャットログが重ならないための左パディング
- */
-const LEFT_METRICS_OFFSET = "200px";
-
-/**
  * NPC応答遅延設定（ミリ秒）
  * テスト環境では0に設定してテスタビリティを向上させる
  */


### PR DESCRIPTION
## 概要

現在失敗している GitHub Actions の CI を通すための修正です。フロントエンド（Jest / ESLint）とバックエンド（Lambda の pytest）の両方の失敗を、ローカルで再現・修正・検証しました。

> 注: upstream `aws-samples/sample-ai-sales-roleplay` への PR 作成はトークン権限（403）で作成できなかったため、まずフォーク内 PR として作成しています。upstream への PR は GitHub UI の「Contribute → Open pull request」から作成してください。

## 修正前の失敗と修正後（すべてローカルで検証済み）

| CI チェック | 修正前 | 修正後 |
|---|---|---|
| `run-tests.yml` frontend Jest (`test:coverage`) | 2 failed / 214 | ✅ 214/214 pass |
| `frontend-checks.yml` / `frontend-lint.yml` ESLint | 4 errors, 3 warnings | ✅ 0（通常 + `ESLINT_FAIL_ON_WARNING=true` 両方） |
| `npx tsc --noEmit` | pass | pass |
| `run-tests.yml` lambda pytest | collection error | ✅ 18/18 pass |

## 根本原因と修正内容

### 1. フロントエンド Jest（`frontend/src/__tests__/components/SessionHistoryList.test.tsx`）
`SessionHistoryPage` は NPC 名と役職を**ネストした要素**（`<Typography>名前<span> (役職)</span></Typography>`）として描画するため、`getByText("テストNPC (銀行員)")` が単一要素に一致せず失敗していました。コンポーネントは正しいので、要素の `textContent` を正規化して比較する `combinedText()` マッチャーを追加してテスト側を修正。

### 2. ESLint（`AvatarStage.tsx` / `ConversationPage.tsx` / `eslint.config.js`）
- `AvatarStage.tsx`: 未使用の `Typography` import と `npcName` の分割代入を削除（`npcName` は呼び出し側が渡すため interface には残置）。
- `ConversationPage.tsx`: 未使用定数 `RIGHT_PANEL_OFFSET` / `LEFT_METRICS_OFFSET` を削除。
- `eslint.config.js`: 生成物が lint ジョブを壊さないよう `coverage` / `node_modules` を `ignores` に追加。

### 3. Lambda pytest（`cdk/lambda/pytest.ini` 新規）
`scenarios/tests/` と `sessions/tests/` の双方に `__init__.py` があり、両方ともパッケージ名が `tests` になって衝突 → `ModuleNotFoundError: No module named 'tests.test_feedback_classification'`。`--import-mode=importlib` を設定して解消。

## テスト

- frontend: `npm ci` → `npm run test:coverage`（214/214）、`npm run lint`（通常/`ESLINT_FAIL_ON_WARNING=true` 両方 0）、`npx tsc --noEmit`（pass）
- lambda: venv 上で `python -m pytest --cov=. --cov-report=xml`（18/18 pass）