### PR TITLE
fix(frontend): Transcribe のアイドルタイムアウト回避と AudioWorklet 移行

### DIFF
--- a/frontend/public/transcribe-audio-processor.js
+++ b/frontend/public/transcribe-audio-processor.js
@@ -1,0 +1,55 @@
+/**
+ * Transcribe 用 AudioWorkletProcessor
+ *
+ * 非推奨の ScriptProcessorNode を置き換えるためのオーディオ処理ワークレット。
+ * オーディオレンダリングスレッド上で以下を行い、結果をメインスレッドへ送る:
+ *   1. 入力（Float32, モノラル）から RMS ベースの音声レベルを算出
+ *   2. Float32 を 16bit PCM (Int16) に変換
+ *
+ * メインスレッドへは { audioLevel: number, pcm: ArrayBuffer } を postMessage する。
+ * pcm は Transferable として転送し、コピーを避ける。
+ *
+ * このファイルは public/ 配下に置き、AudioContext.audioWorklet.addModule() で
+ * '/transcribe-audio-processor.js' として読み込む。
+ */
+class TranscribeAudioProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+
+    // 入力チャンネルが無い場合（無音や未接続）は処理を継続
+    if (!input || input.length === 0) {
+      return true;
+    }
+
+    const channelData = input[0];
+    if (!channelData || channelData.length === 0) {
+      return true;
+    }
+
+    // RMS ベースの音声レベル計算（0-100 スケール）
+    let sum = 0;
+    for (let i = 0; i < channelData.length; i++) {
+      sum += channelData[i] * channelData[i];
+    }
+    const rms = Math.sqrt(sum / channelData.length);
+    const audioLevel = rms * 100;
+
+    // Float32 -> Int16 PCM 変換
+    const pcm = new Int16Array(channelData.length);
+    for (let i = 0; i < channelData.length; i++) {
+      const s = Math.max(-1, Math.min(1, channelData[i]));
+      pcm[i] = Math.max(-32768, Math.min(32767, s * 32767));
+    }
+
+    // メインスレッドへ送信（PCM バッファは Transferable として転送）
+    this.port.postMessage(
+      { audioLevel, pcm: pcm.buffer },
+      [pcm.buffer]
+    );
+
+    // true を返してプロセッサを生かし続ける
+    return true;
+  }
+}
+
+registerProcessor('transcribe-audio-processor', TranscribeAudioProcessor);

--- a/frontend/src/services/TranscribeService.ts
+++ b/frontend/src/services/TranscribeService.ts
@@ -41,8 +41,12 @@ export class TranscribeService {
   private static instance: TranscribeService;
   private transcribeClient: TranscribeStreamingClient | null = null;
   private audioContext: AudioContext | null = null;
-  private audioProcessor: ScriptProcessorNode | null = null;
+  private audioWorkletNode: AudioWorkletNode | null = null;
+  private mediaStreamSource: MediaStreamAudioSourceNode | null = null;
   private mediaStream: MediaStream | null = null;
+  // AudioWorklet モジュール（transcribe-audio-processor.js）を AudioContext ごとに
+  // 一度だけ addModule するためのフラグ管理用
+  private workletModuleLoaded: boolean = false;
   private isRecording: boolean = false;
   private silenceDetectionTimer: ReturnType<typeof setTimeout> | null = null;
   private lastVoiceActivityTime: number = 0;
@@ -61,6 +65,14 @@ export class TranscribeService {
   // 音声データキュー（Transcribe Streaming に流すバッファ）
   private audioQueue: Uint8Array[] = [];
   private isStreaming: boolean = false;
+  // 最後に Transcribe へ音声チャンクを送信した時刻（キープアライブ判定用）
+  private lastAudioSentTime: number = 0;
+  // キープアライブ用の無音PCMチャンク送信間隔（ミリ秒）
+  // Transcribe は「15秒間新しい音声が来ない」とタイムアウトするため、
+  // それより十分短い間隔で無音チャンクを送り続けてセッションを維持する。
+  private readonly keepAliveIntervalMs: number = 5000;
+  // キープアライブ用の無音PCMチャンク（16kHz / 16bit / モノラルの 100ms 相当 = 1600 サンプル）
+  private readonly silentPcmChunk: Uint8Array = new Uint8Array(1600 * 2);
 
   // コールバック関数
   private onTranscriptCallback: ((text: string, isFinal: boolean) => void) | null = null;
@@ -257,18 +269,31 @@ export class TranscribeService {
 
   /**
    * 音声データの AsyncGenerator を作成
-   * audioQueue にデータが積まれるたびに yield する
+   * audioQueue にデータが積まれるたびに yield する。
+   *
+   * 実音声が一定時間送られていない場合は無音PCMチャンクを送信して
+   * Transcribe セッションのタイムアウト（15秒無音で BadRequestException）を防ぐ。
    */
   private async *createAudioStream(): AsyncGenerator<{ AudioEvent: { AudioChunk: Uint8Array } }> {
+    this.lastAudioSentTime = Date.now();
+
     while (!this.abortController?.signal.aborted) {
       if (this.audioQueue.length > 0) {
         const chunk = this.audioQueue.shift();
         if (chunk) {
+          this.lastAudioSentTime = Date.now();
           yield { AudioEvent: { AudioChunk: chunk } };
         }
       } else {
-        // データがない場合は短い待機（CPU を解放）
-        await new Promise(resolve => setTimeout(resolve, 20));
+        // 実音声が keepAliveIntervalMs 以上送られていなければ無音チャンクを送り、
+        // Transcribe のアイドルタイムアウトを回避する。
+        if (Date.now() - this.lastAudioSentTime >= this.keepAliveIntervalMs) {
+          this.lastAudioSentTime = Date.now();
+          yield { AudioEvent: { AudioChunk: this.silentPcmChunk } };
+        } else {
+          // データがない場合は短い待機（CPU を解放）
+          await new Promise(resolve => setTimeout(resolve, 20));
+        }
       }
     }
   }
@@ -341,50 +366,56 @@ export class TranscribeService {
         }
       });
 
+      // 既存の AudioContext が残っていれば閉じてリークを防ぐ
+      if (this.audioContext) {
+        try {
+          await this.audioContext.close();
+        } catch (e) {
+          console.warn('既存AudioContext停止エラー:', e);
+        }
+        this.audioContext = null;
+        this.workletModuleLoaded = false;
+      }
+
       // Web Audio APIを使用してPCM形式で処理
       this.audioContext = new (window.AudioContext || window.webkitAudioContext)({
         sampleRate: 16000
       });
 
+      // 非推奨の ScriptProcessorNode に代わり AudioWorkletNode を使用する。
+      // 音声レベル計算と Float32->Int16 PCM 変換はワークレット側で行い、
+      // 結果を message で受け取る。
+      if (!this.workletModuleLoaded) {
+        await this.audioContext.audioWorklet.addModule('/transcribe-audio-processor.js');
+        this.workletModuleLoaded = true;
+      }
+
       this.mediaStream = stream;
-      const source = this.audioContext.createMediaStreamSource(stream);
-      this.audioProcessor = this.audioContext.createScriptProcessor(4096, 1, 1);
+      this.mediaStreamSource = this.audioContext.createMediaStreamSource(stream);
+      this.audioWorkletNode = new AudioWorkletNode(this.audioContext, 'transcribe-audio-processor', {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        channelCount: 1,
+      });
 
-      this.audioProcessor.onaudioprocess = (event) => {
+      this.audioWorkletNode.port.onmessage = (event: MessageEvent<{ audioLevel: number; pcm: ArrayBuffer }>) => {
         try {
-          const inputBuffer = event.inputBuffer;
-          const inputData = inputBuffer.getChannelData(0);
-
-          // 音声レベルを計算（RMS値）
-          let sum = 0;
-          for (let i = 0; i < inputData.length; i++) {
-            sum += inputData[i] * inputData[i];
-          }
-          const rms = Math.sqrt(sum / inputData.length);
-          const audioLevel = rms * 100; // 0-100のスケールに変換
+          const { audioLevel, pcm } = event.data;
 
           // 音声レベルが閾値を超えている場合のみ音声アクティビティを更新
-          const isVoiceDetected = audioLevel > this.voiceThreshold;
-
-          if (isVoiceDetected) {
+          if (audioLevel > this.voiceThreshold) {
             this.lastVoiceActivityTime = Date.now();
           }
 
-          // Float32ArrayをInt16Arrayに変換（PCM 16bit）
-          const pcmData = new Int16Array(inputData.length);
-          for (let i = 0; i < inputData.length; i++) {
-            pcmData[i] = Math.max(-32768, Math.min(32767, inputData[i] * 32767));
-          }
-
           // Transcribe Streaming のキューに追加
-          this.audioQueue.push(new Uint8Array(pcmData.buffer));
+          this.audioQueue.push(new Uint8Array(pcm));
         } catch (error) {
           console.error('音声データ処理エラー:', error);
         }
       };
 
-      source.connect(this.audioProcessor);
-      this.audioProcessor.connect(this.audioContext.destination);
+      this.mediaStreamSource.connect(this.audioWorkletNode);
+      this.audioWorkletNode.connect(this.audioContext.destination);
 
       // 無音検出タイマーを設定
       this.lastVoiceActivityTime = Date.now();
@@ -456,12 +487,22 @@ export class TranscribeService {
     this.audioQueue = [];
 
     // Web Audio API リソースを停止
-    if (this.audioProcessor) {
+    if (this.audioWorkletNode) {
       try {
-        this.audioProcessor.disconnect();
-        this.audioProcessor = null;
+        this.audioWorkletNode.port.onmessage = null;
+        this.audioWorkletNode.disconnect();
+        this.audioWorkletNode = null;
       } catch (e) {
-        console.warn('AudioProcessor停止エラー:', e);
+        console.warn('AudioWorkletNode停止エラー:', e);
+      }
+    }
+
+    if (this.mediaStreamSource) {
+      try {
+        this.mediaStreamSource.disconnect();
+        this.mediaStreamSource = null;
+      } catch (e) {
+        console.warn('MediaStreamSource停止エラー:', e);
       }
     }
 
@@ -493,6 +534,9 @@ export class TranscribeService {
         console.warn('AudioContext停止エラー:', e);
       }
       this.audioContext = null;
+      // AudioContext を破棄したので、次回は新しい Context に対して
+      // 再度 worklet モジュールを addModule する必要がある。
+      this.workletModuleLoaded = false;
     }
   }
 


### PR DESCRIPTION
## 概要 / Summary

Amazon Transcribe Streaming のブラウザ直接接続（#93）において、音声認識中に発生していた 2 つの問題を修正します。

## 修正1: アイドルタイムアウトによる切断

### 症状
```
BadRequestException: Your request timed out because no new audio was received for 15 seconds.
    at async e.processTranscriptStream (TranscribeService.ts)
```

### 原因
Transcribe Streaming は「15 秒間、新しい音声チャンクが届かない」とセッションを切断します。現行の `createAudioStream()` は `audioQueue` にデータがある時だけチャンクを送るため、録音を開始したまま 15 秒以上無音が続く（話さない・ミュート・離席など）とタイムアウトに至ります。

### 変更内容
`TranscribeService.ts` にキープアライブ処理を追加しました。

- 実音声チャンクを送るたびに送信時刻を記録
- キューが空の状態が `keepAliveIntervalMs`（5 秒）続いたら、無音 PCM チャンク（16kHz / 16bit / モノラルの 100ms 分、ゼロ埋め）を送信

15 秒制限より十分短い間隔で音声が流れ続けるためセッションが維持されます。無音（ゼロ値）なので認識結果には影響しません。

## 修正2: ScriptProcessorNode 非推奨警告の解消

### 症状
```
[Deprecation] The ScriptProcessorNode is deprecated. Use AudioWorkletNode instead.
```

### 変更内容
非推奨の `ScriptProcessorNode` / `onaudioprocess` を `AudioWorkletNode` に移行しました。

- `frontend/public/transcribe-audio-processor.js` を新規追加し、オーディオレンダリングスレッド上で RMS ベースの音声レベル計算と Float32→Int16 PCM 変換を実施
- 結果を `port.postMessage` でメインスレッドへ送信（PCM は Transferable で転送しコピー回避）
- `startListening` で既存 AudioContext を確実に閉じてリークを防止
- `stopListening` / `dispose` のクリーンアップを新ノードに対応

音声レベル計算・PCM 変換・キュー投入のロジックは従来と同等です。

## 検証 / Testing

- `frontend`: `npx tsc -p tsconfig.app.json --noEmit` → エラー 0
- `frontend`: `npx eslint src/services/TranscribeService.ts` → エラー 0
- `frontend`: `npm run build:full` → 成功
- dev 環境へ `cdk deploy` 済み（フロントエンド再ビルド・CloudFront 配信を確認）