### PR TITLE
fix(frontend): 動画録画が開始されない競合状態を修正 (#100)

### DIFF
--- a/frontend/src/__tests__/components/VideoRecorder.test.tsx
+++ b/frontend/src/__tests__/components/VideoRecorder.test.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import VideoRecorder from "../../components/recording/v2/VideoRecorder";
+import type { VideoRecorderRef } from "../../types/components";
+
+// t() はキーをそのまま返し、通知メッセージのキーを検証できるようにする
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// import.meta は CJS の Jest から参照できないため、env ユーティリティを差し替える
+jest.mock("../../utils/env", () => ({
+  isDevEnvironment: () => false,
+}));
+
+/** getUserMedia の解決タイミングをテストから制御するためのヘルパー */
+const createDeferredStream = () => {
+  let resolve!: (stream: MediaStream) => void;
+  const promise = new Promise<MediaStream>((res) => {
+    resolve = res;
+  });
+  const stream = {
+    getTracks: () => [{ stop: jest.fn() }],
+  } as unknown as MediaStream;
+  return { promise, resolve: () => resolve(stream), stream };
+};
+
+class MockMediaRecorder {
+  static instances: MockMediaRecorder[] = [];
+  static isTypeSupported = jest.fn(() => true);
+
+  public state = "inactive";
+  public ondataavailable: ((event: unknown) => void) | null = null;
+  public onstop: (() => void) | null = null;
+  public start = jest.fn(() => {
+    this.state = "recording";
+  });
+  public stop = jest.fn(() => {
+    this.state = "inactive";
+    if (this.onstop) this.onstop();
+  });
+  public addEventListener = jest.fn();
+  public removeEventListener = jest.fn();
+
+  constructor(
+    public stream: MediaStream,
+    public options?: MediaRecorderOptions,
+  ) {
+    MockMediaRecorder.instances.push(this);
+  }
+}
+
+describe("VideoRecorder", () => {
+  let deferred: ReturnType<typeof createDeferredStream>;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    MockMediaRecorder.instances = [];
+    deferred = createDeferredStream();
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia: jest.fn(() => deferred.promise) },
+    });
+    (globalThis as unknown as { MediaRecorder: unknown }).MediaRecorder =
+      MockMediaRecorder;
+
+    // 失敗通知は本番でも console.error に残す仕様のため、テスト出力を汚さないよう抑制する
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it("isActive が true になった後にカメラ初期化が完了しても録画を開始する（Issue #100 の競合状態）", async () => {
+    // isActive が最初から true = カメラ取得が終わる前にセッションが始まったケース
+    render(<VideoRecorder sessionId="session-1" isActive={true} />);
+
+    // カメラ初期化前は録画が始まらない
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+
+    // カメラ取得が完了した時点で録画が開始されること
+    await act(async () => {
+      deferred.resolve();
+    });
+
+    await waitFor(() => {
+      expect(MockMediaRecorder.instances).toHaveLength(1);
+    });
+    expect(MockMediaRecorder.instances[0].start).toHaveBeenCalledWith(100);
+  });
+
+  it("録画開始時に onRecordingStateChange('recording') を通知する", async () => {
+    const onRecordingStateChange = jest.fn();
+    render(
+      <VideoRecorder
+        sessionId="session-1"
+        isActive={true}
+        onRecordingStateChange={onRecordingStateChange}
+      />,
+    );
+
+    await act(async () => {
+      deferred.resolve();
+    });
+
+    await waitFor(() => {
+      expect(onRecordingStateChange).toHaveBeenCalledWith("recording");
+    });
+  });
+
+  it("カメラ取得成功時に onCameraInitialized(true) を通知する", async () => {
+    const onCameraInitialized = jest.fn();
+    render(
+      <VideoRecorder
+        sessionId="session-1"
+        isActive={false}
+        onCameraInitialized={onCameraInitialized}
+      />,
+    );
+
+    await act(async () => {
+      deferred.resolve();
+    });
+
+    await waitFor(() => {
+      expect(onCameraInitialized).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("録画が一度も開始されないままセッションが終了した場合は失敗として通知する", async () => {
+    const onError = jest.fn();
+    const onRecordingStateChange = jest.fn();
+    const recordingFailedListener = jest.fn();
+    window.addEventListener("recordingFailed", recordingFailedListener);
+
+    const ref = React.createRef<VideoRecorderRef>();
+    render(
+      <VideoRecorder
+        ref={ref}
+        sessionId="session-1"
+        isActive={true}
+        onError={onError}
+        onRecordingStateChange={onRecordingStateChange}
+      />,
+    );
+
+    // カメラ取得は完了させない = 録画は開始されない
+    await act(async () => {
+      await ref.current?.forceStopRecording();
+    });
+
+    expect(onError).toHaveBeenCalledWith("recording.notStartedError");
+    expect(onRecordingStateChange).toHaveBeenCalledWith("failed");
+    expect(recordingFailedListener).toHaveBeenCalled();
+
+    window.removeEventListener("recordingFailed", recordingFailedListener);
+  });
+
+  it("録画中にセッションが終了した場合は失敗として通知しない", async () => {
+    const onError = jest.fn();
+    const ref = React.createRef<VideoRecorderRef>();
+    render(
+      <VideoRecorder
+        ref={ref}
+        sessionId="session-1"
+        isActive={true}
+        onError={onError}
+      />,
+    );
+
+    await act(async () => {
+      deferred.resolve();
+    });
+    await waitFor(() => {
+      expect(MockMediaRecorder.instances).toHaveLength(1);
+    });
+
+    // 録画中は addEventListener('stop') 経由で停止完了を待つため、
+    // 停止コールバックを即時に呼び出して Promise を解決させる
+    const recorder = MockMediaRecorder.instances[0];
+    recorder.addEventListener.mockImplementation(
+      (event: string, handler: () => void) => {
+        if (event === "stop") handler();
+      },
+    );
+
+    await act(async () => {
+      await ref.current?.forceStopRecording();
+    });
+
+    expect(onError).not.toHaveBeenCalledWith("recording.notStartedError");
+  });
+});

--- a/frontend/src/components/recording/v2/VideoManager.tsx
+++ b/frontend/src/components/recording/v2/VideoManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 import { Box } from "@mui/material";
 import VideoRecorder from "./VideoRecorder";
+import type { RecordingState } from "./VideoRecorder";
 import type { VideoManagerRef, VideoRecorderRef } from "../../../types/components";
 
 interface VideoManagerProps {
@@ -8,6 +9,7 @@ interface VideoManagerProps {
   sessionStarted: boolean;
   sessionEnded: boolean;
   onCameraInitialized?: (initialized: boolean) => void; // カメラ初期化状態の通知
+  onRecordingStateChange?: (state: RecordingState) => void; // 録画状態の通知
 }
 
 /**
@@ -21,6 +23,7 @@ const VideoManager = forwardRef<VideoManagerRef, VideoManagerProps>(({
   sessionStarted,
   sessionEnded,
   onCameraInitialized,
+  onRecordingStateChange,
 }, ref) => {
   const [videoKey, setVideoKey] = useState<string>("");
   const [recordingError, setRecordingError] = useState<string>("");
@@ -128,6 +131,7 @@ const VideoManager = forwardRef<VideoManagerRef, VideoManagerProps>(({
         onRecordingComplete={handleRecordingComplete}
         onError={handleRecordingError}
         onCameraInitialized={onCameraInitialized}
+        onRecordingStateChange={onRecordingStateChange}
       />
 
       {recordingError && (

--- a/frontend/src/components/recording/v2/VideoRecorder.tsx
+++ b/frontend/src/components/recording/v2/VideoRecorder.tsx
@@ -1,12 +1,26 @@
-import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from "react";
+import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, forwardRef } from "react";
 import { Box, Alert, Snackbar } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import type { VideoRecorderRef } from "../../../types/components";
+import { isDevEnvironment } from "../../../utils/env";
 
 // マルチパートアップロードの1パートあたりのサイズ（10MB、S3の最小5MB以上）
 // 録画動画はファイルサイズに関わらずマルチパートアップロードで送信するため、
 // 長時間セッションの大容量動画（200MB超）でもS3のサイズ制限に達しない
 const MULTIPART_PART_SIZE_BYTES = 10 * 1024 * 1024;
+
+// isActive が true になってから録画開始を待つ猶予時間（ミリ秒）。
+// カメラ初期化のタイムアウト（10秒）より長くし、初期化完了を待って
+// 録画が始まるケースを誤検知しないようにする。
+const RECORDING_START_GRACE_MS = 15000;
+
+/**
+ * 録画の実行状態。親コンポーネントは録画が実際に開始されたかどうかを知る必要がある。
+ * - idle: まだ録画が開始されていない
+ * - recording: 録画が開始された（アップロード完了を待つ価値がある）
+ * - failed: 録画の開始・アップロードに失敗した（待機しても意味がない）
+ */
+export type RecordingState = "idle" | "recording" | "failed";
 
 interface VideoRecorderProps {
   sessionId: string;
@@ -14,6 +28,7 @@ interface VideoRecorderProps {
   onRecordingComplete?: (videoKey: string) => void;
   onError?: (error: string) => void;
   onCameraInitialized?: (initialized: boolean) => void; // カメラ初期化状態の通知
+  onRecordingStateChange?: (state: RecordingState) => void; // 録画状態の通知
 }
 
 /**
@@ -28,6 +43,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
   onRecordingComplete,
   onError,
   onCameraInitialized,
+  onRecordingStateChange,
 }, ref) => {
   const { t } = useTranslation();
 
@@ -37,6 +53,16 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
   const durationTimerRef = useRef<number | null>(null);
+  // プレビューURLの最新値。onstop などの非同期コールバックが state の
+  // 古いクロージャを参照して URL を revoke し損ねるのを防ぐ。
+  const previewUrlRef = useRef<string>("");
+  // このセッションで一度でも録画が開始されたか（停止時の無音失敗を検出するため）
+  const hasStartedRecordingRef = useRef<boolean>(false);
+  // このセッションで録画すべき状態（isActive=true）になったか。
+  // 停止要求時には既に isActive=false になっているため、判定にはこのフラグを使う。
+  const wasActiveRef = useRef<boolean>(false);
+  // カメラ初期化が失敗したか（録画開始の猶予タイマーの二重通知を避けるため）
+  const cameraFailedRef = useRef<boolean>(false);
 
   // state
   const [isAccessGranted, setIsAccessGranted] = useState<boolean>(false);
@@ -46,14 +72,38 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
   const [previewUrl, setPreviewUrl] = useState<string>("");
   const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
 
+  // プレビューURLは ref と state の両方で保持する（下記 previewUrlRef のコメント参照）
+  useEffect(() => {
+    previewUrlRef.current = previewUrl;
+  }, [previewUrl]);
+
+  // 録画の開始・アップロード失敗を利用者と親コンポーネントの両方に伝える。
+  // 「録画されているつもりだったが記録が残っていなかった」状態を防ぐため、
+  // 本番ビルドでも必ず console に残し、Snackbar と onError で明示する。
+  const reportRecordingFailure = useCallback(
+    (messageKey: string, detail?: unknown) => {
+      const message = t(messageKey);
+      console.error(`Recording failure: ${message}`, detail ?? "");
+      setError(message);
+      setSnackbarOpen(true);
+      if (onError) onError(message);
+      if (onRecordingStateChange) onRecordingStateChange("failed");
+      // 呼び出し元（ConversationPage）がアップロード待ちを打ち切れるよう通知する
+      window.dispatchEvent(
+        new CustomEvent("recordingFailed", { detail: { sessionId, message } }),
+      );
+    },
+    [onError, onRecordingStateChange, sessionId, t],
+  );
+
   // カメラアクセスの初期化 - コンポーネントがマウントされた時に一度だけ実行
   useEffect(() => {
-    if (import.meta.env.DEV) console.log("Component mounted");
+    if (isDevEnvironment()) console.log("Component mounted");
 
     // カメラアクセス初期化関数
     const initializeCamera = async () => {
       try {
-        if (import.meta.env.DEV) console.log("Requesting camera access");
+        if (isDevEnvironment()) console.log("Requesting camera access");
         setError("");
 
         // タイムアウト処理を追加（10秒）
@@ -76,15 +126,21 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
         // ストリームをrefに保存
         streamRef.current = stream;
 
+        // <video> 要素がまだマウントされていない場合でもカメラ初期化は完了扱いにする。
+        // srcObject の割り当ては videoRef が利用可能になった時点で別の useEffect が行う。
+        // （以前は videoRef.current が null だと isAccessGranted が永久に false のままで、
+        //  録画が一切開始されなかった）
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
-          setIsAccessGranted(true);
-          if (import.meta.env.DEV) console.log("Camera initialized");
-          // 親コンポーネントにカメラ初期化完了を通知
-          if (onCameraInitialized) onCameraInitialized(true);
         }
+        cameraFailedRef.current = false;
+        setIsAccessGranted(true);
+        if (isDevEnvironment()) console.log("Camera initialized");
+        // 親コンポーネントにカメラ初期化完了を通知
+        if (onCameraInitialized) onCameraInitialized(true);
       } catch (error) {
         console.error("Camera access error:", error);
+        cameraFailedRef.current = true;
         setError(t("recording.cameraAccessError"));
         setSnackbarOpen(true);
         if (onError) onError(t("recording.cameraAccessError"));
@@ -98,16 +154,42 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
 
     // クリーンアップ関数
     return () => {
-      if (import.meta.env.DEV) console.log("Component unmounting - releasing resources");
+      if (isDevEnvironment()) console.log("Component unmounting - releasing resources");
       stopRecording();
       releaseCamera();
     };
+    // カメラ初期化はマウント時に一度だけ行う意図的な処理のため exhaustive-deps を無効化する。
+    // （録画開始を制御する下の useEffect では無効化していない。依存漏れを ESLint に
+    //  検出させるためであり、isAccessGranted の漏れが本 Issue の原因だった）
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // 空の依存配列でコンポーネントのマウント時に一度だけ実行
 
+  // カメラストリームを <video> 要素へ割り当てる。
+  // カメラ初期化の完了と <video> のマウント順序に依存しないよう、初期化本体から分離している。
+  useEffect(() => {
+    // プレビュー再生中（previewUrl あり）は src 属性を使うため srcObject は設定しない
+    if (previewUrl) return;
+    if (videoRef.current && streamRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+    }
+  }, [previewUrl, isAccessGranted]);
+
+  // 最新の startRecording / stopRecording を保持する ref。
+  // これらの関数は毎レンダー再生成されるため依存配列に直接入れると effect が無駄に再実行される。
+  // ref 経由で呼ぶことで、依存配列を「録画すべきかどうかを決める値」だけに保ちつつ
+  // exhaustive-deps を満たせる（= 依存漏れを ESLint が検出できる状態を維持できる）。
+  const startRecordingRef = useRef<() => void>(() => {});
+  const stopRecordingRef = useRef<() => void>(() => {});
+
+  // セッションが切り替わったら録画状態のフラグをリセットする
+  useEffect(() => {
+    hasStartedRecordingRef.current = false;
+    wasActiveRef.current = false;
+  }, [sessionId]);
+
   // isActive プロパティが変更された時の処理
   useEffect(() => {
-    if (import.meta.env.DEV) console.log(
+    if (isDevEnvironment()) console.log(
       "isActive changed:",
       isActive,
       "recording:",
@@ -118,24 +200,43 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
       isAccessGranted,
     );
 
+    if (isActive && sessionId) {
+      wasActiveRef.current = true;
+    }
+
     if (isActive && !isRecording && sessionId) {
       // セッションがアクティブで、sessionIdが有効な場合のみ録画開始
       // カメラ初期化が完了していれば即座に録画開始
       if (isAccessGranted) {
-        if (import.meta.env.DEV) console.log("Camera initialized, starting recording");
-        startRecording();
+        if (isDevEnvironment()) console.log("Camera initialized, starting recording");
+        startRecordingRef.current();
       } else {
-        if (import.meta.env.DEV) console.log("Waiting for camera initialization, recording deferred");
+        // カメラ初期化の完了を待つ。isAccessGranted が依存配列に含まれているため、
+        // 初期化完了時にこの effect が再実行されて録画が開始される。
+        if (isDevEnvironment()) console.log("Waiting for camera initialization, recording deferred");
       }
     } else if (!isActive && isRecording) {
       // セッションが非アクティブになったら録画停止
-      stopRecording();
+      stopRecordingRef.current();
     } else if (isActive && !sessionId) {
       // sessionIdが無効な場合は警告を出力
       console.warn("Recording start requested but sessionId is empty");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActive, isRecording, sessionId]);
+  }, [isActive, isRecording, sessionId, isAccessGranted]);
+
+  // 録画開始の監視。isActive になってから猶予時間内に録画が開始されない場合は、
+  // 無音のまま録画されないことを防ぐため利用者と親コンポーネントに明示する。
+  useEffect(() => {
+    if (!isActive || !sessionId || isRecording || isAccessGranted) return;
+
+    const timeoutId = window.setTimeout(() => {
+      // カメラアクセス自体が失敗している場合は既に通知済みなので二重に出さない
+      if (cameraFailedRef.current) return;
+      reportRecordingFailure("recording.notStartedError");
+    }, RECORDING_START_GRACE_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isActive, sessionId, isRecording, isAccessGranted, reportRecordingFailure]);
 
   // カメラストリームを解放
   const releaseCamera = () => {
@@ -151,9 +252,10 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
 
     setIsAccessGranted(false);
 
-    // プレビューURL解放
-    if (previewUrl) {
-      URL.revokeObjectURL(previewUrl);
+    // プレビューURL解放（ref を使い、古いクロージャの値を参照しないようにする）
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = "";
       setPreviewUrl("");
     }
   };
@@ -162,12 +264,10 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
   const startRecording = () => {
     if (isRecording || !isAccessGranted) return;
 
-    if (import.meta.env.DEV) console.log("Recording started");
+    if (isDevEnvironment()) console.log("Recording started");
 
     if (!streamRef.current) {
-      console.error("Camera stream not available");
-      setError(t("recording.cameraNotInitialized"));
-      setSnackbarOpen(true);
+      reportRecordingFailure("recording.cameraNotInitialized");
       return;
     }
 
@@ -199,21 +299,21 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
 
       // 録画停止時の処理
       mediaRecorderRef.current.onstop = () => {
-        if (import.meta.env.DEV) console.log("Recording stopped");
+        if (isDevEnvironment()) console.log("Recording stopped");
 
         try {
           // MP4形式でBlobを作成
           const blob = new Blob(chunksRef.current, { type: "video/mp4" });
-          if (import.meta.env.DEV) console.log(
+          if (isDevEnvironment()) console.log(
             "Recording blob size:",
             blob.size,
             "bytes",
             "MIME type: video/mp4",
           );
 
-          // 以前のURLを解放
-          if (previewUrl) {
-            URL.revokeObjectURL(previewUrl);
+          // 以前のURLを解放（ref を使い、古いクロージャの値を参照しないようにする）
+          if (previewUrlRef.current) {
+            URL.revokeObjectURL(previewUrlRef.current);
           }
 
           // 有効なBlobのみURLを作成
@@ -224,10 +324,12 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
             // 録画データを保存
             saveRecordingData(blob);
           } else {
-            console.warn("Empty blob generated");
+            // 空のBlobはアップロードされないため、待機側が90秒待たされないよう失敗として通知する
+            reportRecordingFailure("recording.emptyRecordingError");
           }
         } catch (err) {
           console.error("Recording data processing error:", err);
+          reportRecordingFailure("recording.recordingDataProcessingFailed", err);
         }
 
         // 録画時間をリセット
@@ -237,13 +339,12 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
 
       // 録画開始
       mediaRecorderRef.current.start(100); // 100msごとにデータを取得
+      hasStartedRecordingRef.current = true;
       setIsRecording(true);
       startDurationTimer();
+      if (onRecordingStateChange) onRecordingStateChange("recording");
     } catch (error) {
-      console.error("Recording start error:", error);
-      setError(t("recording.startError"));
-      setSnackbarOpen(true);
-      if (onError) onError(t("recording.startError"));
+      reportRecordingFailure("recording.startError", error);
     }
   };
 
@@ -251,7 +352,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
   const stopRecording = () => {
     if (!isRecording || !mediaRecorderRef.current) return;
 
-    if (import.meta.env.DEV) console.log("Recording stopped");
+    if (isDevEnvironment()) console.log("Recording stopped");
 
     try {
       if (mediaRecorderRef.current.state !== "inactive") {
@@ -262,6 +363,10 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
       console.error("Recording stop error:", error);
     }
   };
+
+  // 上の isActive 監視 effect から最新の実装を呼べるようにする（latest ref パターン）
+  startRecordingRef.current = startRecording;
+  stopRecordingRef.current = stopRecording;
 
   // 録画時間タイマー開始
   const startDurationTimer = () => {
@@ -311,7 +416,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
           throw new Error(`ETag header not found for part ${partNumber}`);
         }
 
-        if (import.meta.env.DEV) {
+        if (isDevEnvironment()) {
           console.log(`Part ${partNumber} uploaded: eTag=${eTag}`);
         }
         return eTag;
@@ -355,7 +460,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
     const partCount = Math.ceil(blob.size / MULTIPART_PART_SIZE_BYTES);
     const fileName = videoKey.split("/").pop() || "recording.mp4";
 
-    if (import.meta.env.DEV) {
+    if (isDevEnvironment()) {
       console.log(
         `Multipart upload start: size=${Math.round(blob.size / 1024 / 1024 * 100) / 100}MB, parts=${partCount}`,
       );
@@ -380,7 +485,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
       // 全パート完了後、S3にパート結合を指示
       await apiService.completeMultipartUpload(serverVideoKey, uploadId, uploadedParts);
 
-      if (import.meta.env.DEV) console.log("Multipart upload success:", serverVideoKey);
+      if (isDevEnvironment()) console.log("Multipart upload success:", serverVideoKey);
 
       // サーバー採番のキーで保存・通知し、フロント/バックエンドのキーを一致させる
       safeSetLocalStorage("lastRecordingKey", serverVideoKey);
@@ -411,7 +516,7 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
 
       // ローカルの仮キー。アップロード成功時はサーバー採番のキーで上書きする
       const localVideoKey = `session_${sessionId}_${new Date().getTime()}.mp4`;
-      if (import.meta.env.DEV) console.log("S3 upload start:", localVideoKey, "size:", Math.round(blob.size / 1024 / 1024 * 100) / 100, "MB");
+      if (isDevEnvironment()) console.log("S3 upload start:", localVideoKey, "size:", Math.round(blob.size / 1024 / 1024 * 100) / 100, "MB");
 
       // マルチパートアップロードでS3に保存する
       // ファイルサイズに関わらずマルチパート方式に統一しており、
@@ -421,15 +526,13 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
       try {
         resultVideoKey = await uploadWithMultipart(blob, sessionId, localVideoKey);
       } catch (uploadError) {
-        console.error("S3 upload process error:", uploadError);
-        // エラーが発生した場合でも、親コンポーネントにエラー情報を渡す
-        if (onError) {
-          onError(t("recording.uploadError"));
-        }
+        // アップロード失敗は利用者に明示し、待機側（ConversationPage）が
+        // 90秒のタイムアウトを待たずに進めるよう通知する
+        reportRecordingFailure("recording.uploadError", uploadError);
         // エラーが発生してもvideoKeyは渡して処理を続行
       }
 
-      if (import.meta.env.DEV) console.log("Recording data saved:", resultVideoKey);
+      if (isDevEnvironment()) console.log("Recording data saved:", resultVideoKey);
 
       // コールバックを呼び出し（エラーが発生してもvideoKeyは渡す）
       // 成功時はサーバー採番のキー、失敗時はローカル仮キーを渡す
@@ -437,24 +540,21 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
         onRecordingComplete(resultVideoKey);
       }
     } catch (err) {
-      console.error("Recording data processing failed:", err);
-      if (onError) {
-        onError(t("recording.recordingDataProcessingFailed"));
-      }
+      reportRecordingFailure("recording.recordingDataProcessingFailed", err);
     }
   };
 
   // 明示的な録画停止のためのメソッドを外部に公開
   useImperativeHandle(ref, () => ({
     forceStopRecording: async () => {
-      if (import.meta.env.DEV) console.log("VideoRecorder: forceStopRecording called");
+      if (isDevEnvironment()) console.log("VideoRecorder: forceStopRecording called");
       return new Promise<void>((resolve) => {
         if (isRecording && mediaRecorderRef.current) {
-          if (import.meta.env.DEV) console.log("VideoRecorder: Recording in progress, stopping");
+          if (isDevEnvironment()) console.log("VideoRecorder: Recording in progress, stopping");
 
           // 録画停止完了を待つためのイベントリスナーを設定
           const handleStop = () => {
-            if (import.meta.env.DEV) console.log("VideoRecorder: Recording stopped");
+            if (isDevEnvironment()) console.log("VideoRecorder: Recording stopped");
             if (mediaRecorderRef.current) {
               mediaRecorderRef.current.removeEventListener('stop', handleStop);
             }
@@ -464,7 +564,16 @@ const VideoRecorder = forwardRef<VideoRecorderRef, VideoRecorderProps>(({
           mediaRecorderRef.current.addEventListener('stop', handleStop);
           stopRecording();
         } else {
-          if (import.meta.env.DEV) console.log("VideoRecorder: Not recording, skipping stop");
+          // 録画が一度も開始されていない状態で停止が要求された場合は、
+          // 「正常に停止した」ように見せず失敗として明示する。
+          // （従来はここで黙って resolve していたため、録画されていないことに気づけなかった）
+          // 停止要求時点では既に isActive=false になっているため、
+          // 「このセッションで録画すべきだったか」は wasActiveRef で判定する。
+          if (wasActiveRef.current && !hasStartedRecordingRef.current) {
+            reportRecordingFailure("recording.notStartedError");
+          } else if (isDevEnvironment()) {
+            console.log("VideoRecorder: Not recording, skipping stop");
+          }
           resolve();
         }
       });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -911,7 +911,10 @@
     "s3UploadStart": "Starting S3 upload of recording data",
     "signedUrlObtained": "Signed URL obtained",
     "s3UploadProcessError": "S3 upload process error",
-    "browserNotSupported": "Your browser does not support MP4 recording"
+    "browserNotSupported": "Your browser does not support MP4 recording",
+    "notStartedError": "Recording could not be started. This session was not recorded, so video-based performance analysis will not be available. Please check your camera permissions.",
+    "emptyRecordingError": "The recording was empty and could not be saved. Video-based performance analysis will not be available.",
+    "waitingForUpload": "Uploading the recording. Please wait until it finishes..."
   },
   "videoFeedback": {
     "title": "Expression & Gesture Analysis",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -911,7 +911,10 @@
     "s3UploadStart": "録画データをS3にアップロード開始",
     "signedUrlObtained": "署名付きURLを取得しました",
     "s3UploadProcessError": "S3アップロード処理エラー",
-    "browserNotSupported": "お使いのブラウザはMP4形式の録画をサポートしていません"
+    "browserNotSupported": "お使いのブラウザはMP4形式の録画をサポートしていません",
+    "notStartedError": "録画を開始できませんでした。この商談は録画されておらず、映像を使ったパフォーマンス分析は行われません。カメラの許可設定をご確認ください。",
+    "emptyRecordingError": "録画データが空のため保存できませんでした。映像を使ったパフォーマンス分析は行われません。",
+    "waitingForUpload": "録画をアップロードしています。完了するまでこのままお待ちください..."
   },
   "videoFeedback": {
     "title": "表情・身振り分析",

--- a/frontend/src/pages/ConversationPage.tsx
+++ b/frontend/src/pages/ConversationPage.tsx
@@ -1472,26 +1472,14 @@ const ConversationPage: React.FC = () => {
               </Box>
             )}
 
-            {/* カメラプレビュー（左カラム下部） */}
-            {videoRecordingEnabled && (
-              <Box
-                data-testid="video-manager-container"
-                sx={{
-                  borderTop: "1px solid",
-                  borderColor: "divider",
-                  p: 1,
-                }}
-              >
-                <VideoManager
-                  ref={undefined}
-                  sessionId={sessionId}
-                  sessionStarted={sessionStarted}
-                  sessionEnded={sessionEnded}
-                  onCameraInitialized={handleCameraInitialized}
-                onRecordingStateChange={handleRecordingStateChange}
-                />
-              </Box>
-            )}
+            {/*
+              カメラプレビューは中央カラムの先頭に単一インスタンスとして常時マウントする。
+              以前はここ（左カラム下部・開始後用）と中央カラム（開始前用）に別々の
+              VideoManager を条件付きで置いていたため、sessionStarted が false→true に
+              変わる瞬間に片方がアンマウント・もう片方がマウントされ、カメラが停止・再取得
+              されて「セッション開始時にカメラがオフになる」現象が起きていた。
+              単一インスタンス化により再マウントを防ぐ（中央カラム側の配置を参照）。
+            */}
           </Box>
         )}
 
@@ -1509,16 +1497,27 @@ const ConversationPage: React.FC = () => {
         >
           {/* アバターなし時：メトリクスは右パネルにのみ表示（アバターあり版と統一） */}
 
-          {/* セッション開始前のカメラプレビュー */}
-          {videoRecordingEnabled && !sessionStarted && (
+          {/*
+            カメラプレビュー（単一インスタンス）。
+            開始前・開始後とも常に存在する中央カラムの先頭にインライン配置する。
+            以前は開始前用（中央カラム）と開始後用（左カラム下部）に別々の VideoManager を
+            条件付きでマウントしていたため、sessionStarted が false→true になる瞬間に
+            片方がアンマウント・もう片方がマウントされ、カメラが停止・再取得されて
+            「セッション開始時にカメラがオフになる」現象が起きていた。
+            また開始後用は avatarVisible にも依存していたため、アバター無効シナリオでは
+            開始後にプレビューが表示されず録画も始まらなかった。
+            単一インスタンス化により再マウントを防ぎ、インライン配置により
+            ヘッダーやメトリクスパネルへの重なりも避ける。
+          */}
+          {videoRecordingEnabled && (
             <Box
               data-testid="video-manager-container"
               sx={{
-                position: "absolute",
-                top: 12,
-                left: 12,
-                zIndex: 10,
-                width: 180,
+                flexShrink: 0,
+                alignSelf: "flex-start",
+                // 開始前は映りを確認しやすいよう少し大きく、開始後は会話領域を広く保つため小さく
+                width: sessionStarted ? 140 : 200,
+                m: 1,
                 borderRadius: 2,
                 overflow: "hidden",
                 boxShadow: "0 1px 4px rgba(0,0,0,0.12)",

--- a/frontend/src/pages/ConversationPage.tsx
+++ b/frontend/src/pages/ConversationPage.tsx
@@ -29,6 +29,7 @@ import {
   mergeGoalStatus,
 } from "../utils/goalUtils";
 import VideoManager from "../components/recording/v2/VideoManager";
+import type { RecordingState } from "../components/recording/v2/VideoRecorder";
 import {
   loadVideoRecordingEnabled,
   saveVideoRecordingEnabled,
@@ -53,7 +54,7 @@ import SessionSettingsPanel from "../components/conversation/SessionSettingsPane
 import SlideTray from "../components/conversation/SlideTray";
 import SlideZoomModal from "../components/conversation/SlideZoomModal";
 import type { SlideImageInfo } from "../types/api";
-import { Dialog, DialogTitle, DialogContent } from "@mui/material";
+import { Dialog, DialogTitle, DialogContent, Backdrop, CircularProgress, Typography } from "@mui/material";
 
 /**
  * NPC応答遅延設定（ミリ秒）
@@ -65,6 +66,13 @@ const NPC_RESPONSE_BASE_DELAY = import.meta.env.VITE_NPC_RESPONSE_DELAY
 const NPC_RESPONSE_RANDOM_DELAY = import.meta.env.VITE_NPC_RESPONSE_DELAY
   ? 0
   : 1000;
+
+/**
+ * 録画アップロード完了を待つ最大時間（ミリ秒）。
+ * 大容量動画のマルチパートアップロードを考慮した値。
+ * 録画が開始されていない場合はそもそも待機しない（Issue #100）。
+ */
+const RECORDING_UPLOAD_TIMEOUT_MS = 90000;
 
 /**
  * 会話ページコンポーネント
@@ -198,6 +206,10 @@ const ConversationPage: React.FC = () => {
   const [isCameraInitialized, setIsCameraInitialized] = useState<boolean>(false);
   // カメラエラー状態管理
   const [cameraError, setCameraError] = useState<boolean>(false);
+  // 録画の実行状態。録画が実際に開始されていない場合はアップロード完了を待たずに遷移する
+  const recordingStateRef = useRef<RecordingState>("idle");
+  // 録画アップロード待機中フラグ（画面に待機中であることを表示するため）
+  const [isWaitingForUpload, setIsWaitingForUpload] = useState<boolean>(false);
   // ビデオ録画機能のオン/オフ設定（localStorageで永続化、デフォルトはオン）
   const [videoRecordingEnabled, setVideoRecordingEnabled] = useState<boolean>(
     loadVideoRecordingEnabled,
@@ -213,6 +225,7 @@ const ConversationPage: React.FC = () => {
     if (!videoRecordingEnabled) {
       setIsCameraInitialized(false);
       setCameraError(false);
+      recordingStateRef.current = "idle";
     }
   }, [videoRecordingEnabled]);
 
@@ -996,11 +1009,19 @@ const ConversationPage: React.FC = () => {
           // 前回の録画キーを保存（新しいセッションの録画を待つため）
           const previousKey = localStorage.getItem("lastRecordingKey");
 
-          // 90秒でタイムアウト（大きなファイル対応）
-          const timeoutId = setTimeout(() => {
+          // タイマー・リスナーを一箇所で片付けて resolve する
+          const finish = () => {
+            if (uploadCompleted) return;
+            uploadCompleted = true;
+            clearTimeout(timeoutId);
+            clearInterval(checkInterval);
             window.removeEventListener('recordingComplete', handleRecordingComplete as EventListener);
+            window.removeEventListener('recordingFailed', handleRecordingFailed);
             resolve();
-          }, 90000);
+          };
+
+          // 90秒でタイムアウト（大きなファイル対応）
+          const timeoutId = setTimeout(finish, RECORDING_UPLOAD_TIMEOUT_MS);
 
           const checkUploadComplete = (newVideoKey?: string) => {
             if (uploadCompleted) return;
@@ -1012,11 +1033,8 @@ const ConversationPage: React.FC = () => {
             // 2. 前回のキーと異なること（または前回のキーがない場合）
             if (videoKey && videoKey.includes(session.id)) {
               if (!previousKey || videoKey !== previousKey) {
-                uploadCompleted = true;
                 localStorage.setItem(`session_${session.id}_videoKey`, videoKey);
-                clearTimeout(timeoutId);
-                window.removeEventListener('recordingComplete', handleRecordingComplete as EventListener);
-                resolve();
+                finish();
               } else {
                 // 前回と同じキーのためスキップ
               }
@@ -1032,7 +1050,14 @@ const ConversationPage: React.FC = () => {
             }
           };
 
+          // 録画の開始・アップロードが失敗した場合は待機しても完了しないため、
+          // タイムアウトを待たずに打ち切って採点画面へ進む
+          const handleRecordingFailed = () => {
+            finish();
+          };
+
           window.addEventListener('recordingComplete', handleRecordingComplete as EventListener);
+          window.addEventListener('recordingFailed', handleRecordingFailed);
 
           // 定期的にlocalStorageをチェック（イベントが発火しない場合の対策）
           const checkInterval = setInterval(() => {
@@ -1040,24 +1065,29 @@ const ConversationPage: React.FC = () => {
               const currentKey = localStorage.getItem("lastRecordingKey");
               if (currentKey && currentKey.includes(session.id) && currentKey !== previousKey) {
                 checkUploadComplete(currentKey);
-                clearInterval(checkInterval);
               }
             } else {
               clearInterval(checkInterval);
             }
           }, 1000);
-
-          // タイムアウト時にインターバルもクリア
-          setTimeout(() => {
-            clearInterval(checkInterval);
-          }, 90000);
         });
       };
 
-      // 録画アップロード完了を待ってから遷移
-      // ビデオ録画が無効な場合は待機をスキップ
-      if (videoRecordingEnabled) {
-        await waitForRecordingUpload();
+      // 録画アップロード完了を待ってから遷移する。
+      // ただし録画が実際に開始されていない場合はアップロードイベントが永遠に来ないため、
+      // 90秒のタイムアウトを無駄に待たずに即座に次へ進む（Issue #100）。
+      if (videoRecordingEnabled && recordingStateRef.current === "recording") {
+        // 待機中であることを画面に表示し、「フリーズした」ように見えないようにする
+        setIsWaitingForUpload(true);
+        try {
+          await waitForRecordingUpload();
+        } finally {
+          setIsWaitingForUpload(false);
+        }
+      } else if (videoRecordingEnabled) {
+        console.warn(
+          `Skipping recording upload wait: recording state is "${recordingStateRef.current}"`,
+        );
       }
 
       // セッション分析を非同期で開始（Step Functions）
@@ -1283,6 +1313,12 @@ const ConversationPage: React.FC = () => {
     }
   }, []);
 
+  // 録画状態のハンドラー。
+  // 録画が実際に開始されたかどうかで、セッション終了時にアップロード完了を待つか判断する。
+  const handleRecordingStateChange = useCallback((state: RecordingState) => {
+    recordingStateRef.current = state;
+  }, []);
+
   // ゴール達成時の通知表示
   useEffect(() => {
     // 前回のゴール状態と比較して新たに達成されたゴールを検出
@@ -1452,6 +1488,7 @@ const ConversationPage: React.FC = () => {
                   sessionStarted={sessionStarted}
                   sessionEnded={sessionEnded}
                   onCameraInitialized={handleCameraInitialized}
+                onRecordingStateChange={handleRecordingStateChange}
                 />
               </Box>
             )}
@@ -1493,6 +1530,7 @@ const ConversationPage: React.FC = () => {
                 sessionStarted={sessionStarted}
                 sessionEnded={sessionEnded}
                 onCameraInitialized={handleCameraInitialized}
+                onRecordingStateChange={handleRecordingStateChange}
               />
             </Box>
           )}
@@ -1656,6 +1694,22 @@ const ConversationPage: React.FC = () => {
           />
         </DialogContent>
       </Dialog>
+
+      {/* 録画アップロード待機中の表示。
+          待機中に画面が固まったように見えるのを防ぐ（Issue #100） */}
+      <Backdrop
+        open={isWaitingForUpload}
+        data-testid="recording-upload-backdrop"
+        sx={{
+          color: "#fff",
+          zIndex: (theme) => theme.zIndex.modal + 1,
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        <CircularProgress color="inherit" />
+        <Typography variant="body1">{t("recording.waitingForUpload")}</Typography>
+      </Backdrop>
     </Box>
   );
 };

--- a/frontend/src/utils/env.ts
+++ b/frontend/src/utils/env.ts
@@ -1,0 +1,9 @@
+/**
+ * ビルド環境の判定ユーティリティ。
+ *
+ * `import.meta` は ESM 専用の構文であり、CommonJS で実行される Jest から
+ * 直接参照するコンポーネントはテスト時にパースエラーになる。
+ * 参照箇所をこのモジュールに集約することで、テストでは
+ * `jest.mock("../../utils/env", ...)` によって差し替えられるようにしている。
+ */
+export const isDevEnvironment = (): boolean => Boolean(import.meta.env?.DEV);


### PR DESCRIPTION

## 概要

Issue #100 の「動画録画が開始されず S3 にアップロードされない」競合状態を修正します。Issue で挙げられた 4 つの要望すべてに対応しました。

Closes #100

## 原因

`frontend/src/components/recording/v2/VideoRecorder.tsx` の `isActive` 監視 `useEffect` の依存配列に `isAccessGranted` が含まれていませんでした。

1. マウント時に `initializeCamera()` が非同期でカメラ取得を開始する
2. カメラ取得完了より先に `isActive` が `true` になると `isAccessGranted` はまだ `false`
3. 「録画を延期」の分岐に入って何もしない
4. その後 `isAccessGranted` が `true` になっても依存配列に無いため `useEffect` が再実行されない
5. 録画は開始されないままセッションが終了する

## 変更内容

### 1. 競合状態の修正（本体）

- `isActive` 監視 `useEffect` の依存配列に `isAccessGranted` を追加し、`eslint-disable-next-line react-hooks/exhaustive-deps` を**外しました**。今後同種の依存漏れは ESLint が検出します。
- `startRecording` / `stopRecording` は毎レンダー再生成されるため、依存配列に入れると effect が無駄に再実行されます。latest ref パターンで参照することで、依存配列を「録画すべきかどうかを決める値」だけに保ったまま exhaustive-deps を満たしています。
- カメラ初期化のマウント時 1 回 `useEffect` のみ意図的に `eslint-disable` を残し、その理由をコメントで明記しました。

### 2. カメラ初期化完了の判定を `videoRef` から切り離し

`getUserMedia` が成功していても `videoRef.current` が `null` だと `isAccessGranted` が永久に `false` のままになる問題を修正しました。ストリーム取得成功時点で `setIsAccessGranted(true)` とし、`<video>` への `srcObject` 割り当ては別の `useEffect` が `videoRef` 利用可能時に行います。

### 3. 録画されていないことを利用者に明示

失敗通知を `reportRecordingFailure()` に集約し、**本番ビルドでも** `console.error` + Snackbar + `onError`（→ `VideoManager` のエラー表示）+ `recordingFailed` イベントで必ず通知します。対象:

- 録画開始の失敗 / カメラ未初期化 / MP4 非対応
- 空の Blob（従来は `console.warn` のみで無音）
- マルチパートアップロードの失敗
- **録画が一度も開始されないままセッションが終了したケース** — `forceStopRecording()` が「正常停止」を装わず失敗として通知します（従来はここで黙って resolve していたため気づけませんでした）
- 保険として、`isActive` になってから 15 秒以内に録画が開始されない場合も通知します

i18n キー `recording.notStartedError` / `recording.emptyRecordingError` / `recording.waitingForUpload` を ja / en 両方に追加しました。

### 4. 90 秒待機の改善

`frontend/src/pages/ConversationPage.tsx` の `waitForRecordingUpload()`:

- **録画が実際に開始されていない場合は待機せず即座に採点画面へ進みます**（`onRecordingStateChange` で `VideoRecorder` → `VideoManager` → `ConversationPage` に録画状態を伝搬）
- 待機する場合は Backdrop + スピナー + メッセージで**待機中であることを画面に表示**します（従来は「フリーズした」ように見えていました）
- `recordingFailed` イベントを受け取った時点でタイムアウトを待たず打ち切ります
- タイマーとイベントリスナーの解放を `finish()` に一本化しました（従来はタイムアウト経路で `checkInterval` と一部リスナーが残っていました）

### 5. テスト追加のための副作用

`import.meta` は ESM 専用構文のため、CommonJS で動く Jest から `VideoRecorder` をレンダリングすると `SyntaxError: Cannot use 'import.meta' outside a module` になり、このコンポーネントは一切ユニットテストできませんでした。参照を `frontend/src/utils/env.ts` の `isDevEnvironment()` に集約し、テストから `jest.mock` で差し替えられるようにしました（`VideoRecorder.tsx` 内の 20 箇所を置換）。

## テスト

`frontend/src/__tests__/components/VideoRecorder.test.tsx` を追加（5 件）:

- `isActive` が `true` になった後にカメラ初期化が完了しても録画を開始する（本 Issue の競合状態の回帰テスト）
- 録画開始時に `onRecordingStateChange("recording")` を通知する
- カメラ取得成功時に `onCameraInitialized(true)` を通知する
- 録画が一度も開始されないままセッションが終了した場合は失敗として通知する
- 録画中にセッションが終了した場合は失敗として通知しない

依存配列の修正を巻き戻すと上記のうち 3 件が失敗することを確認済みで、回帰テストとして機能します。

## 検証

- `npx tsc --noEmit` — エラーなし
- `npx eslint .` — 0 error / 0 warning
- `npm run build` — 成功（警告は既存のもののみ）
- `npm test` — **219 passed / 219**（既存 214 件はすべて維持、追加 5 件）


---

## 追加修正: セッション開始時にカメラがオフになる問題

dev 環境での動作確認中に、上記の競合状態とは別に「セッション開始のたびにカメラが一瞬オフになる」問題が見つかったため、本 PR に含めます。

### 原因

`ConversationPage.tsx` が `VideoManager` を **2 箇所に条件付きでマウント**していました。

- 開始前用: 中央カラム（`videoRecordingEnabled && !sessionStarted`）
- 開始後用: 左カラム下部（`sessionStarted && avatarVisible` の内側）

`sessionStarted` が `false` → `true` に変わると、React ツリー上の別の場所にある 2 つの `VideoManager` が「片方アンマウント・もう片方マウント」で入れ替わります。`VideoRecorder` はマウント時に `getUserMedia`、アンマウント時に `releaseCamera()` で `track.stop()` するため、セッション開始のたびにカメラが停止・再取得されていました。

さらに開始後用は `avatarVisible` にも依存していたため、**アバター無効シナリオではセッション開始後にプレビューが表示されず、録画も開始されませんでした**。

### 変更内容

開始前・開始後とも常に存在する**中央カラムの先頭に単一インスタンスとしてインライン配置**し、再マウントを防ぎます。

- 左カラム（アバター）は `sessionStarted && avatarVisible`、右カラム（メトリクス）は `sessionStarted && rightPanelsVisible` の条件付きのため、そこに置くと再マウントが再発します。中央カラムは唯一、開始前後とも常に存在します。
- `position: absolute` のフローティング配置ではなくインライン配置にすることで、ヘッダーやメトリクスパネル（怒りメーター等）への重なりも解消しました。
- プレビュー幅は開始前 200px / 開始後 140px で出し分けています。

### 検証

- `npx tsc -p tsconfig.app.json --noEmit` — エラーなし
- `npx eslint .` — 0 error / 0 warning
- `npm run build` — 成功
- `npm test` — **219 passed / 219**
- dev 環境へ `cdk deploy` し、実機ブラウザでセッション開始時にカメラがオフにならないこと、プレビューが他パネルに重ならないことを確認
